### PR TITLE
feat(foundation): add scaffold and test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 node_modules/
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
 .codebase-context/
 *.bak
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# Commit messages follow Conventional Commits:
+#   <type>(optional-scope): <short imperative summary>
+#
+# Valid types: feat, fix, docs, style, refactor, test, chore, ci, build, perf, revert.
+# Examples:
+#   feat(foundation): add config dataclass
+#   test: add fixture setup script
+repos:
+  - repo: local
+    hooks:
+      - id: compass-commit-message
+        name: Compass commit message convention
+        entry: python scripts/validate_commit_msg.py
+        language: system
+        stages: [commit-msg]

--- a/compass/__init__.py
+++ b/compass/__init__.py
@@ -1,0 +1,7 @@
+"""Compass project analysis package."""
+
+from compass.config import CompassConfig
+
+__all__ = [
+    "CompassConfig",
+]

--- a/compass/__main__.py
+++ b/compass/__main__.py
@@ -1,0 +1,7 @@
+"""Run Compass as ``python -m compass``."""
+
+from compass.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compass/cli.py
+++ b/compass/cli.py
@@ -1,0 +1,68 @@
+"""Thin CLI entry point for Compass."""
+
+from __future__ import annotations
+
+import argparse
+
+from compass.config import CompassConfig
+from compass.log import configure_logging
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="compass",
+        description="Analyze a repository and generate Compass outputs.",
+    )
+    parser.add_argument("target_path", nargs="?", help="Path to the target repository.")
+    parser.add_argument(
+        "--adapters",
+        default="rules",
+        help='Comma-separated adapters to run, or "all". Defaults to "rules".',
+    )
+    parser.add_argument(
+        "--provider",
+        choices=("claude", "codex"),
+        help="LLM provider to use. Falls back to config.yaml when omitted.",
+    )
+    parser.add_argument(
+        "--lang",
+        default="auto",
+        choices=("auto", "python", "typescript"),
+        help='Target language. Defaults to "auto".',
+    )
+    parser.add_argument(
+        "--reanalyze",
+        action="store_true",
+        help="Rebuild analysis context instead of reusing cached state.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        help='Console log level. Defaults to "WARNING".',
+    )
+    return parser
+
+
+def parse_adapters(value: str) -> list[str]:
+    return [adapter.strip() for adapter in value.split(",") if adapter.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+
+    if args.target_path is None:
+        parser.print_help()
+        return 0
+
+    CompassConfig(
+        target_path=args.target_path,
+        adapters=parse_adapters(args.adapters),
+        provider=args.provider,
+        lang=args.lang,
+        reanalyze=args.reanalyze,
+    )
+    parser.exit(2, "Compass runner is not implemented yet.\n")
+    return 2

--- a/compass/config.py
+++ b/compass/config.py
@@ -1,0 +1,16 @@
+"""Shared Compass configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CompassConfig:
+    """Configuration passed unchanged from the CLI boundary into the runner."""
+
+    target_path: str
+    adapters: list[str] = field(default_factory=lambda: ["rules"])
+    provider: str | None = None
+    lang: str = "auto"
+    reanalyze: bool = False

--- a/compass/log.py
+++ b/compass/log.py
@@ -1,0 +1,34 @@
+"""Logging helpers for Compass."""
+
+from __future__ import annotations
+
+import logging
+
+
+LOGGER_NAME = "compass"
+
+
+def configure_logging(level: str | int = logging.WARNING) -> None:
+    """Configure simple console logging for CLI usage."""
+
+    logging.basicConfig(
+        level=_coerce_level(level),
+        format="%(levelname)s: %(message)s",
+    )
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a logger under the Compass namespace."""
+
+    if name is None:
+        return logging.getLogger(LOGGER_NAME)
+    return logging.getLogger(f"{LOGGER_NAME}.{name}")
+
+
+def _coerce_level(level: str | int) -> int:
+    if isinstance(level, int):
+        return level
+    coerced = logging.getLevelName(level.upper())
+    if isinstance(coerced, int):
+        return coerced
+    raise ValueError(f"Unknown log level: {level}")

--- a/compass/paths.py
+++ b/compass/paths.py
@@ -1,0 +1,45 @@
+"""Centralized path helpers for Compass outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+COMPASS_DIRNAME = ".compass"
+OUTPUT_DIRNAME = "output"
+
+
+@dataclass(frozen=True)
+class CompassPaths:
+    """Computed paths under a target repository's .compass directory."""
+
+    target_path: Path
+
+    @property
+    def compass_dir(self) -> Path:
+        return self.target_path / COMPASS_DIRNAME
+
+    @property
+    def analysis_context(self) -> Path:
+        return self.compass_dir / "analysis_context.json"
+
+    @property
+    def repo_state(self) -> Path:
+        return self.compass_dir / "repo_state.json"
+
+    @property
+    def output_dir(self) -> Path:
+        return self.compass_dir / OUTPUT_DIRNAME
+
+    @property
+    def rules_yaml(self) -> Path:
+        return self.output_dir / "rules.yaml"
+
+    @property
+    def summary_md(self) -> Path:
+        return self.output_dir / "summary.md"
+
+
+def compass_paths(target_path: str | Path) -> CompassPaths:
+    return CompassPaths(Path(target_path))

--- a/docs/foundation-team-update.md
+++ b/docs/foundation-team-update.md
@@ -1,0 +1,30 @@
+# Foundation Update For All Teams
+
+The foundation branch now includes a commit message convention hook via
+pre-commit.
+
+Run this once locally after pulling the branch:
+
+```bash
+pip install pre-commit
+pre-commit install --hook-type commit-msg
+```
+
+Commit messages must use Conventional Commits:
+
+```text
+<type>(optional-scope): <short summary>
+```
+
+Allowed types:
+
+```text
+feat, fix, docs, style, refactor, test, chore, ci, build, perf, revert
+```
+
+Examples:
+
+```text
+feat(foundation): add config dataclass
+test: add fixture setup script
+```

--- a/scripts/validate_commit_msg.py
+++ b/scripts/validate_commit_msg.py
@@ -1,0 +1,42 @@
+"""Validate Compass commit messages for the pre-commit commit-msg hook."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+PATTERN = re.compile(
+    r"^(feat|fix|docs|style|refactor|test|chore|ci|build|perf|revert)"
+    r"(\([a-z0-9._-]+\))?: .{1,72}$"
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print("Usage: validate_commit_msg.py <commit-msg-file>", file=sys.stderr)
+        return 2
+
+    message = Path(args[0]).read_text(encoding="utf-8").strip()
+    first_line = message.splitlines()[0] if message else ""
+    if PATTERN.match(first_line):
+        return 0
+
+    print(
+        "Invalid commit message.\n\n"
+        "Use Conventional Commits:\n"
+        "  <type>(optional-scope): <short summary>\n\n"
+        "Allowed types: feat, fix, docs, style, refactor, test, chore, ci, "
+        "build, perf, revert.\n"
+        "Examples:\n"
+        "  feat(foundation): add config dataclass\n"
+        "  test: add fixture setup script",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+"""Shared pytest configuration for Compass tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests in addition to unit tests.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "integration: marks tests as integration",
+    )
+
+
+def pytest_cmdline_main(config: pytest.Config) -> int | None:
+    if not config.getoption("--run-integration"):
+        return None
+
+    ignores = getattr(config.option, "ignore", None)
+    if ignores is None:
+        return None
+
+    config.option.ignore = [
+        ignore for ignore in ignores if Path(str(ignore)) != Path("tests/integration")
+    ]
+    return None
+
+
+def pytest_ignore_collect(
+    collection_path: Path,
+    config: pytest.Config,
+) -> bool | None:
+    if config.getoption("--run-integration"):
+        return None
+    integration_dir = Path(str(config.rootpath)) / "tests" / "integration"
+    try:
+        collection_path.relative_to(integration_dir)
+    except ValueError:
+        return None
+    return True
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
+        session.exitstatus = pytest.ExitCode.OK

--- a/tests/fixtures/sample_repo_minimal/README.md
+++ b/tests/fixtures/sample_repo_minimal/README.md
@@ -1,0 +1,3 @@
+# Minimal Fixture
+
+A tiny generic repo.

--- a/tests/fixtures/sample_repo_minimal/config.ini
+++ b/tests/fixtures/sample_repo_minimal/config.ini
@@ -1,0 +1,2 @@
+[fixture]
+name = minimal

--- a/tests/fixtures/sample_repo_minimal/notes.txt
+++ b/tests/fixtures/sample_repo_minimal/notes.txt
@@ -1,0 +1,1 @@
+first note

--- a/tests/fixtures/sample_repo_python/CONTRIBUTING.md
+++ b/tests/fixtures/sample_repo_python/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Prefer explicit errors and small modules.

--- a/tests/fixtures/sample_repo_python/README.md
+++ b/tests/fixtures/sample_repo_python/README.md
@@ -1,0 +1,1 @@
+# Python Fixture

--- a/tests/fixtures/sample_repo_python/pyproject.toml
+++ b/tests/fixtures/sample_repo_python/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = 'sample-app'
+version = '0.1.0'

--- a/tests/fixtures/sample_repo_python/src/sample_app/__init__.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/__init__.py
@@ -1,0 +1,1 @@
+from .service import UserService as UserService

--- a/tests/fixtures/sample_repo_python/src/sample_app/api.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/api.py
@@ -1,0 +1,5 @@
+from .models import User
+from .service import UserService
+
+def handle(name: str) -> User:
+    return UserService().load(name)

--- a/tests/fixtures/sample_repo_python/src/sample_app/cache.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/cache.py
@@ -1,0 +1,1 @@
+CACHE: dict[str, str] = {}

--- a/tests/fixtures/sample_repo_python/src/sample_app/cli.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/cli.py
@@ -1,0 +1,4 @@
+from .api import handle
+
+def main() -> None:
+    handle('Ada')

--- a/tests/fixtures/sample_repo_python/src/sample_app/config.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/config.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Settings:
+    retries: int = 3

--- a/tests/fixtures/sample_repo_python/src/sample_app/errors.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/errors.py
@@ -1,0 +1,2 @@
+class AppError(Exception):
+    pass

--- a/tests/fixtures/sample_repo_python/src/sample_app/events.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/events.py
@@ -1,0 +1,2 @@
+def publish(event: str) -> None:
+    print(event)

--- a/tests/fixtures/sample_repo_python/src/sample_app/models.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/models.py
@@ -1,0 +1,7 @@
+class User:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @property
+    def slug(self) -> str:
+        return self.name.lower().replace(' ', '-')

--- a/tests/fixtures/sample_repo_python/src/sample_app/repository.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/repository.py
@@ -1,0 +1,5 @@
+from .models import User
+
+class UserRepository:
+    def get(self, name: str) -> User:
+        return User(name)

--- a/tests/fixtures/sample_repo_python/src/sample_app/service.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/service.py
@@ -1,0 +1,23 @@
+from collections.abc import Callable
+
+from .models import User
+from .repository import UserRepository
+
+def audited(func: Callable[[object, str], User]) -> Callable[[object, str], User]:
+    return func
+
+class UserService:
+    def __init__(self) -> None:
+        self.repository = UserRepository()
+
+    @staticmethod
+    def normalize(name: str) -> str:
+        return name.strip()
+
+    @audited
+    def load(self, name: str) -> User:
+        try:
+            user = self.repository.get(self.normalize(name))
+            return user
+        except ValueError as exc:
+            raise RuntimeError('could not load user') from exc

--- a/tests/fixtures/sample_repo_python/src/sample_app/tasks.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/tasks.py
@@ -1,0 +1,4 @@
+from .service import UserService
+
+def refresh() -> None:
+    UserService().load('Grace')

--- a/tests/fixtures/sample_repo_python/src/sample_app/utils.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/utils.py
@@ -1,0 +1,2 @@
+def join_words(words: list[str]) -> str:
+    return ' '.join(words)

--- a/tests/fixtures/sample_repo_python/src/sample_app/validators.py
+++ b/tests/fixtures/sample_repo_python/src/sample_app/validators.py
@@ -1,0 +1,3 @@
+def require_name(name: str) -> None:
+    if not name:
+        raise ValueError('name is required')

--- a/tests/fixtures/sample_repo_python/tests/test_service.py
+++ b/tests/fixtures/sample_repo_python/tests/test_service.py
@@ -1,0 +1,4 @@
+from sample_app.service import UserService
+
+def test_normalize() -> None:
+    assert UserService.normalize(' Ada ') == 'Ada'

--- a/tests/fixtures/sample_repo_typescript/CONTRIBUTING.md
+++ b/tests/fixtures/sample_repo_typescript/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Prefer async boundaries and typed interfaces.

--- a/tests/fixtures/sample_repo_typescript/README.md
+++ b/tests/fixtures/sample_repo_typescript/README.md
@@ -1,0 +1,1 @@
+# TypeScript Fixture

--- a/tests/fixtures/sample_repo_typescript/package.json
+++ b/tests/fixtures/sample_repo_typescript/package.json
@@ -1,0 +1,1 @@
+{"name":"sample-ts","version":"0.1.0","type":"module"}

--- a/tests/fixtures/sample_repo_typescript/src/api.ts
+++ b/tests/fixtures/sample_repo_typescript/src/api.ts
@@ -1,0 +1,5 @@
+import { UserService } from './service';
+
+export async function handle(id: string) {
+  return new UserService().load(id);
+}

--- a/tests/fixtures/sample_repo_typescript/src/cache.ts
+++ b/tests/fixtures/sample_repo_typescript/src/cache.ts
@@ -1,0 +1,1 @@
+export const cache = new Map<string, string>();

--- a/tests/fixtures/sample_repo_typescript/src/decorators.ts
+++ b/tests/fixtures/sample_repo_typescript/src/decorators.ts
@@ -1,0 +1,3 @@
+export function logged(_: unknown, _key: string, descriptor: PropertyDescriptor) {
+  return descriptor;
+}

--- a/tests/fixtures/sample_repo_typescript/src/errors.ts
+++ b/tests/fixtures/sample_repo_typescript/src/errors.ts
@@ -1,0 +1,1 @@
+export class AppError extends Error {}

--- a/tests/fixtures/sample_repo_typescript/src/events.ts
+++ b/tests/fixtures/sample_repo_typescript/src/events.ts
@@ -1,0 +1,3 @@
+export function publish(event: string): void {
+  console.log(event);
+}

--- a/tests/fixtures/sample_repo_typescript/src/index.ts
+++ b/tests/fixtures/sample_repo_typescript/src/index.ts
@@ -1,0 +1,1 @@
+export { handle } from './api';

--- a/tests/fixtures/sample_repo_typescript/src/repository.ts
+++ b/tests/fixtures/sample_repo_typescript/src/repository.ts
@@ -1,0 +1,7 @@
+import type { User } from './types';
+
+export class UserRepository {
+  async get(id: string): Promise<User> {
+    return { id, name: 'Ada' };
+  }
+}

--- a/tests/fixtures/sample_repo_typescript/src/service.ts
+++ b/tests/fixtures/sample_repo_typescript/src/service.ts
@@ -1,0 +1,16 @@
+import { logged } from './decorators';
+import { UserRepository } from './repository';
+
+export class UserService {
+  constructor(private readonly repository = new UserRepository()) {}
+
+  @logged
+  async load(id: string) {
+    try {
+      const user = await this.repository.get(id);
+      return user;
+    } catch (error) {
+      throw new Error('could not load user', { cause: error });
+    }
+  }
+}

--- a/tests/fixtures/sample_repo_typescript/src/tasks.ts
+++ b/tests/fixtures/sample_repo_typescript/src/tasks.ts
@@ -1,0 +1,5 @@
+import { handle } from './api';
+
+export async function refresh() {
+  await handle('ada');
+}

--- a/tests/fixtures/sample_repo_typescript/src/types.ts
+++ b/tests/fixtures/sample_repo_typescript/src/types.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string;
+  name: string;
+}

--- a/tests/fixtures/sample_repo_typescript/src/utils.ts
+++ b/tests/fixtures/sample_repo_typescript/src/utils.ts
@@ -1,0 +1,3 @@
+export function joinWords(words: string[]): string {
+  return words.join(' ');
+}

--- a/tests/fixtures/sample_repo_typescript/src/validators.ts
+++ b/tests/fixtures/sample_repo_typescript/src/validators.ts
@@ -1,0 +1,3 @@
+export function requireId(id: string): void {
+  if (!id) throw new Error('id is required');
+}

--- a/tests/fixtures/sample_repo_typescript/tests/service.test.ts
+++ b/tests/fixtures/sample_repo_typescript/tests/service.test.ts
@@ -1,0 +1,3 @@
+import { UserService } from '../src/service';
+
+void new UserService().load('ada');

--- a/tests/fixtures/sample_repo_typescript/tsconfig.json
+++ b/tests/fixtures/sample_repo_typescript/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"strict":true,"target":"ES2022"}}

--- a/tests/fixtures/setup.sh
+++ b/tests/fixtures/setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+reset_repo() {
+  local repo_name="$1"
+  rm -rf "${ROOT_DIR:?}/${repo_name}"
+  mkdir -p "${ROOT_DIR}/${repo_name}"
+  git -C "${ROOT_DIR}/${repo_name}" init --quiet
+  git -C "${ROOT_DIR}/${repo_name}" config user.name "Compass Fixtures"
+  git -C "${ROOT_DIR}/${repo_name}" config user.email "fixtures@compass.local"
+}
+
+commit_all() {
+  local repo_name="$1"
+  local message="$2"
+  git -C "${ROOT_DIR}/${repo_name}" add .
+  git -C "${ROOT_DIR}/${repo_name}" commit --quiet -m "${message}"
+}
+
+write_file() {
+  local path="$1"
+  mkdir -p "$(dirname "${path}")"
+  printf '%s\n' "${@:2}" > "${path}"
+}
+
+setup_minimal() {
+  local repo="sample_repo_minimal"
+  reset_repo "${repo}"
+  write_file "${ROOT_DIR}/${repo}/README.md" "# Minimal Fixture" "" "A tiny generic repo."
+  write_file "${ROOT_DIR}/${repo}/notes.txt" "first note"
+  commit_all "${repo}" "feat: add minimal fixture"
+  write_file "${ROOT_DIR}/${repo}/config.ini" "[fixture]" "name = minimal"
+  commit_all "${repo}" "chore: add fixture config"
+}
+
+setup_python() {
+  local repo="sample_repo_python"
+  reset_repo "${repo}"
+  mkdir -p "${ROOT_DIR}/${repo}/src/sample_app" "${ROOT_DIR}/${repo}/tests"
+  write_file "${ROOT_DIR}/${repo}/CONTRIBUTING.md" "# Contributing" "" "Prefer explicit errors and small modules."
+  write_file "${ROOT_DIR}/${repo}/README.md" "# Python Fixture"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/__init__.py" "from .service import UserService as UserService"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/config.py" "from dataclasses import dataclass" "" "@dataclass(frozen=True)" "class Settings:" "    retries: int = 3"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/errors.py" "class AppError(Exception):" "    pass"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/models.py" "class User:" "    def __init__(self, name: str) -> None:" "        self.name = name" "" "    @property" "    def slug(self) -> str:" "        return self.name.lower().replace(' ', '-')"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/repository.py" "from .models import User" "" "class UserRepository:" "    def get(self, name: str) -> User:" "        return User(name)"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/service.py" "from collections.abc import Callable" "" "from .models import User" "from .repository import UserRepository" "" "def audited(func: Callable[[object, str], User]) -> Callable[[object, str], User]:" "    return func" "" "class UserService:" "    def __init__(self) -> None:" "        self.repository = UserRepository()" "" "    @staticmethod" "    def normalize(name: str) -> str:" "        return name.strip()" "" "    @audited" "    def load(self, name: str) -> User:" "        try:" "            return self.repository.get(self.normalize(name))" "        except ValueError as exc:" "            raise RuntimeError('could not load user') from exc"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/api.py" "from .models import User" "from .service import UserService" "" "def handle(name: str) -> User:" "    return UserService().load(name)"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/cli.py" "from .api import handle" "" "def main() -> None:" "    handle('Ada')"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/cache.py" "CACHE: dict[str, str] = {}"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/events.py" "def publish(event: str) -> None:" "    print(event)"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/validators.py" "def require_name(name: str) -> None:" "    if not name:" "        raise ValueError('name is required')"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/tasks.py" "from .service import UserService" "" "def refresh() -> None:" "    UserService().load('Grace')"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/utils.py" "def join_words(words: list[str]) -> str:" "    return ' '.join(words)"
+  write_file "${ROOT_DIR}/${repo}/tests/test_service.py" "from sample_app.service import UserService" "" "def test_normalize() -> None:" "    assert UserService.normalize(' Ada ') == 'Ada'"
+  write_file "${ROOT_DIR}/${repo}/pyproject.toml" "[project]" "name = 'sample-app'" "version = '0.1.0'"
+  commit_all "${repo}" "feat: add python fixture app"
+  write_file "${ROOT_DIR}/${repo}/src/sample_app/service.py" "from collections.abc import Callable" "" "from .models import User" "from .repository import UserRepository" "" "def audited(func: Callable[[object, str], User]) -> Callable[[object, str], User]:" "    return func" "" "class UserService:" "    def __init__(self) -> None:" "        self.repository = UserRepository()" "" "    @staticmethod" "    def normalize(name: str) -> str:" "        return name.strip()" "" "    @audited" "    def load(self, name: str) -> User:" "        try:" "            user = self.repository.get(self.normalize(name))" "            return user" "        except ValueError as exc:" "            raise RuntimeError('could not load user') from exc"
+  commit_all "${repo}" "fix: update hot service path"
+}
+
+setup_typescript() {
+  local repo="sample_repo_typescript"
+  reset_repo "${repo}"
+  mkdir -p "${ROOT_DIR}/${repo}/src" "${ROOT_DIR}/${repo}/tests"
+  write_file "${ROOT_DIR}/${repo}/CONTRIBUTING.md" "# Contributing" "" "Prefer async boundaries and typed interfaces."
+  write_file "${ROOT_DIR}/${repo}/README.md" "# TypeScript Fixture"
+  write_file "${ROOT_DIR}/${repo}/package.json" '{"name":"sample-ts","version":"0.1.0","type":"module"}'
+  write_file "${ROOT_DIR}/${repo}/tsconfig.json" '{"compilerOptions":{"strict":true,"target":"ES2022"}}'
+  write_file "${ROOT_DIR}/${repo}/src/types.ts" "export interface User {" "  id: string;" "  name: string;" "}"
+  write_file "${ROOT_DIR}/${repo}/src/errors.ts" "export class AppError extends Error {}"
+  write_file "${ROOT_DIR}/${repo}/src/decorators.ts" "export function logged(_: unknown, _key: string, descriptor: PropertyDescriptor) {" "  return descriptor;" "}"
+  write_file "${ROOT_DIR}/${repo}/src/repository.ts" "import type { User } from './types';" "" "export class UserRepository {" "  async get(id: string): Promise<User> {" "    return { id, name: 'Ada' };" "  }" "}"
+  write_file "${ROOT_DIR}/${repo}/src/service.ts" "import { logged } from './decorators';" "import { UserRepository } from './repository';" "" "export class UserService {" "  constructor(private readonly repository = new UserRepository()) {}" "" "  @logged" "  async load(id: string) {" "    try {" "      return await this.repository.get(id);" "    } catch (error) {" "      throw new Error('could not load user', { cause: error });" "    }" "  }" "}"
+  write_file "${ROOT_DIR}/${repo}/src/api.ts" "import { UserService } from './service';" "" "export async function handle(id: string) {" "  return new UserService().load(id);" "}"
+  write_file "${ROOT_DIR}/${repo}/src/index.ts" "export { handle } from './api';"
+  write_file "${ROOT_DIR}/${repo}/src/cache.ts" "export const cache = new Map<string, string>();"
+  write_file "${ROOT_DIR}/${repo}/src/events.ts" "export function publish(event: string): void {" "  console.log(event);" "}"
+  write_file "${ROOT_DIR}/${repo}/src/validators.ts" "export function requireId(id: string): void {" "  if (!id) throw new Error('id is required');" "}"
+  write_file "${ROOT_DIR}/${repo}/src/tasks.ts" "import { handle } from './api';" "" "export async function refresh() {" "  await handle('ada');" "}"
+  write_file "${ROOT_DIR}/${repo}/src/utils.ts" "export function joinWords(words: string[]): string {" "  return words.join(' ');" "}"
+  write_file "${ROOT_DIR}/${repo}/tests/service.test.ts" "import { UserService } from '../src/service';" "" "void new UserService().load('ada');"
+  commit_all "${repo}" "feat: add typescript fixture app"
+  write_file "${ROOT_DIR}/${repo}/src/service.ts" "import { logged } from './decorators';" "import { UserRepository } from './repository';" "" "export class UserService {" "  constructor(private readonly repository = new UserRepository()) {}" "" "  @logged" "  async load(id: string) {" "    try {" "      const user = await this.repository.get(id);" "      return user;" "    } catch (error) {" "      throw new Error('could not load user', { cause: error });" "    }" "  }" "}"
+  commit_all "${repo}" "fix: update hot service path"
+}
+
+setup_minimal
+setup_python
+setup_typescript

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test package for Compass."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit test package for Compass."""


### PR DESCRIPTION
## Summary
- Add Compass package scaffold files for CLI entry, config, logging, paths, and package exports
- Add commit-msg pre-commit hook with Conventional Commits validation
- Add shared pytest infrastructure and synthetic fixture repos for minimal, Python, and TypeScript cases

## Notes
- `pyproject.toml` and `compass/errors.py` are intentionally not included because they are owned by another teammate.
- Fixture `.git/` directories are generated by `tests/fixtures/setup.sh` and are not committed.

## Verification
- `compass --help` works
- commit-msg hook blocks invalid messages and passes valid Conventional Commits
- `tests/fixtures/setup.sh` is idempotent
- `pytest` and `pytest --run-integration` run with 0 tests collected
