### PR TITLE
chore: add pydantic to runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
   "mcp",
   # Needed for .compass/config.yaml and ~/.compass/config.yaml parsing.
   "PyYAML>=6.0",
+  # Output validation schemas.
+  "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #32

## Summary

Audited all imports across `compass/` and found `pydantic` used in both schema files (`rules_schema.py`, `summary_schema.py`) but missing from `[project.dependencies]` in `pyproject.toml`.

All other imports are either Python stdlib or already listed.

## Changes

- `pyproject.toml` — added `pydantic>=2.0` to runtime dependencies

## Why `>=2.0`

The schemas use `field_validator` and `model_validator`, which are Pydantic v2-only APIs.