### PR TITLE
fix: apply ruff formatting to schema files

### DIFF
--- a/compass/schemas/rules_schema.py
+++ b/compass/schemas/rules_schema.py
@@ -35,141 +35,144 @@ from pydantic import BaseModel, field_validator, model_validator
 # Schema models
 # ---------------------------------------------------------------------------
 
+
 class Rule(BaseModel):
-    id: str
-    rule: str
-    why: str
-    example: str
+	id: str
+	rule: str
+	why: str
+	example: str
 
-    @field_validator("id")
-    @classmethod
-    def id_format(cls, v: str) -> str:
-        pattern = r"^[a-z][a-z0-9]*(-[a-z0-9]+)*-\d{2}$"
-        if not re.match(pattern, v):
-            raise ValueError(
-                f"Rule id '{v}' does not match expected format. "
-                "Expected kebab-case prefix followed by a two-digit number "
-                "(e.g. 'err-01', 'phase-boundary-02')."
-            )
-        return v
+	@field_validator('id')
+	@classmethod
+	def id_format(cls, v: str) -> str:
+		pattern = r'^[a-z][a-z0-9]*(-[a-z0-9]+)*-\d{2}$'
+		if not re.match(pattern, v):
+			raise ValueError(
+				f"Rule id '{v}' does not match expected format. "
+				'Expected kebab-case prefix followed by a two-digit number '
+				"(e.g. 'err-01', 'phase-boundary-02')."
+			)
+		return v
 
-    @field_validator("rule", "why", "example")
-    @classmethod
-    def no_empty_strings(cls, v: str, info: Any) -> str:
-        if not v.strip():
-            raise ValueError(f"Field '{info.field_name}' must not be empty.")
-        return v
+	@field_validator('rule', 'why', 'example')
+	@classmethod
+	def no_empty_strings(cls, v: str, info: Any) -> str:
+		if not v.strip():
+			raise ValueError(f"Field '{info.field_name}' must not be empty.")
+		return v
 
 
 class Cluster(BaseModel):
-    name: str
-    context: str
-    golden_file: str
-    rules: list[Rule]
+	name: str
+	context: str
+	golden_file: str
+	rules: list[Rule]
 
-    @field_validator("name", "context", "golden_file")
-    @classmethod
-    def no_empty_strings(cls, v: str, info: Any) -> str:
-        if not v.strip():
-            raise ValueError(f"Field '{info.field_name}' must not be empty.")
-        return v
+	@field_validator('name', 'context', 'golden_file')
+	@classmethod
+	def no_empty_strings(cls, v: str, info: Any) -> str:
+		if not v.strip():
+			raise ValueError(f"Field '{info.field_name}' must not be empty.")
+		return v
 
-    @field_validator("rules")
-    @classmethod
-    def at_least_one_rule(cls, v: list[Rule]) -> list[Rule]:
-        if not v:
-            raise ValueError("Each cluster must contain at least one rule.")
-        return v
+	@field_validator('rules')
+	@classmethod
+	def at_least_one_rule(cls, v: list[Rule]) -> list[Rule]:
+		if not v:
+			raise ValueError('Each cluster must contain at least one rule.')
+		return v
 
 
 class RulesOutput(BaseModel):
-    clusters: list[Cluster]
+	clusters: list[Cluster]
 
-    @field_validator("clusters")
-    @classmethod
-    def at_least_one_cluster(cls, v: list[Cluster]) -> list[Cluster]:
-        if not v:
-            raise ValueError("rules.yaml must contain at least one cluster.")
-        return v
+	@field_validator('clusters')
+	@classmethod
+	def at_least_one_cluster(cls, v: list[Cluster]) -> list[Cluster]:
+		if not v:
+			raise ValueError('rules.yaml must contain at least one cluster.')
+		return v
 
-    @model_validator(mode="after")
-    def rule_ids_unique(self) -> RulesOutput:
-        seen: set[str] = set()
-        duplicates: list[str] = []
-        for cluster in self.clusters:
-            for rule in cluster.rules:
-                if rule.id in seen:
-                    duplicates.append(rule.id)
-                seen.add(rule.id)
-        if duplicates:
-            raise ValueError(
-                f"Rule ids must be unique across all clusters. "
-                f"Duplicates found: {', '.join(duplicates)}"
-            )
-        return self
+	@model_validator(mode='after')
+	def rule_ids_unique(self) -> RulesOutput:
+		seen: set[str] = set()
+		duplicates: list[str] = []
+		for cluster in self.clusters:
+			for rule in cluster.rules:
+				if rule.id in seen:
+					duplicates.append(rule.id)
+				seen.add(rule.id)
+		if duplicates:
+			raise ValueError(
+				f'Rule ids must be unique across all clusters. '
+				f'Duplicates found: {", ".join(duplicates)}'
+			)
+		return self
 
 
 # ---------------------------------------------------------------------------
 # Validation result
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ValidationResult:
-    valid: bool
-    errors: list[str] = field(default_factory=list)
+	valid: bool
+	errors: list[str] = field(default_factory=list)
 
-    def __bool__(self) -> bool:
-        return self.valid
+	def __bool__(self) -> bool:
+		return self.valid
 
 
 # ---------------------------------------------------------------------------
 # Public interface
 # ---------------------------------------------------------------------------
 
+
 def validate_rules(data: dict[str, Any]) -> ValidationResult:
-    """
-    Validate a parsed rules.yaml dict against the locked Compass schema.
+	"""
+	Validate a parsed rules.yaml dict against the locked Compass schema.
 
-    Args:
-        data: The result of yaml.safe_load() on a rules.yaml file.
+	Args:
+	    data: The result of yaml.safe_load() on a rules.yaml file.
 
-    Returns:
-        ValidationResult with valid=True and empty errors list on success,
-        or valid=False with a list of human-readable error messages on failure.
+	Returns:
+	    ValidationResult with valid=True and empty errors list on success,
+	    or valid=False with a list of human-readable error messages on failure.
 
-    Example:
-        import yaml
-        from compass.schemas.rules_schema import validate_rules
+	Example:
+	    import yaml
+	    from compass.schemas.rules_schema import validate_rules
 
-        with open(".compass/output/rules.yaml") as f:
-            data = yaml.safe_load(f)
+	    with open(".compass/output/rules.yaml") as f:
+	        data = yaml.safe_load(f)
 
-        result = validate_rules(data)
-        if not result.valid:
-            for error in result.errors:
-                print(f"  - {error}")
-    """
-    try:
-        RulesOutput.model_validate(data)
-        return ValidationResult(valid=True)
-    except Exception as exc:
-        errors = _extract_errors(exc)
-        return ValidationResult(valid=False, errors=errors)
+	    result = validate_rules(data)
+	    if not result.valid:
+	        for error in result.errors:
+	            print(f"  - {error}")
+	"""
+	try:
+		RulesOutput.model_validate(data)
+		return ValidationResult(valid=True)
+	except Exception as exc:
+		errors = _extract_errors(exc)
+		return ValidationResult(valid=False, errors=errors)
 
 
 def _extract_errors(exc: Exception) -> list[str]:
-    """
-    Convert a pydantic ValidationError into a flat list of readable strings.
-    Each string names the location in the document and what went wrong.
-    """
-    from pydantic import ValidationError
+	"""
+	Convert a pydantic ValidationError into a flat list of readable strings.
+	Each string names the location in the document and what went wrong.
+	"""
+	from pydantic import ValidationError
 
-    if not isinstance(exc, ValidationError):
-        return [str(exc)]
+	if not isinstance(exc, ValidationError):
+		return [str(exc)]
 
-    errors: list[str] = []
-    for error in exc.errors():
-        location = " → ".join(str(part) for part in error["loc"]) if error["loc"] else "root"
-        message = error["msg"]
-        errors.append(f"{location}: {message}")
-    return errors
+	errors: list[str] = []
+	for error in exc.errors():
+		location = ' → '.join(str(part) for part in error['loc']) if error['loc'] else 'root'
+		message = error['msg']
+		errors.append(f'{location}: {message}')
+	return errors

--- a/compass/schemas/summary_schema.py
+++ b/compass/schemas/summary_schema.py
@@ -54,173 +54,176 @@ from pydantic import BaseModel, field_validator, model_validator
 # Schema models
 # ---------------------------------------------------------------------------
 
-class ReadFirstEntry(BaseModel):
-    path: str
-    reason: str
 
-    @field_validator("path", "reason")
-    @classmethod
-    def no_empty_strings(cls, v: str, info: Any) -> str:
-        if not v.strip():
-            raise ValueError(f"Field '{info.field_name}' must not be empty.")
-        return v
+class ReadFirstEntry(BaseModel):
+	path: str
+	reason: str
+
+	@field_validator('path', 'reason')
+	@classmethod
+	def no_empty_strings(cls, v: str, info: Any) -> str:
+		if not v.strip():
+			raise ValueError(f"Field '{info.field_name}' must not be empty.")
+		return v
 
 
 class FileNote(BaseModel):
-    """Shared shape for stable[] and hotspots[] entries."""
-    path: str
-    note: str
+	"""Shared shape for stable[] and hotspots[] entries."""
 
-    @field_validator("path", "note")
-    @classmethod
-    def no_empty_strings(cls, v: str, info: Any) -> str:
-        if not v.strip():
-            raise ValueError(f"Field '{info.field_name}' must not be empty.")
-        return v
+	path: str
+	note: str
+
+	@field_validator('path', 'note')
+	@classmethod
+	def no_empty_strings(cls, v: str, info: Any) -> str:
+		if not v.strip():
+			raise ValueError(f"Field '{info.field_name}' must not be empty.")
+		return v
 
 
 class CouplingPair(BaseModel):
-    """Two file paths that co-change. Validated as a two-element list."""
-    files: list[str]
+	"""Two file paths that co-change. Validated as a two-element list."""
 
-    @model_validator(mode="before")
-    @classmethod
-    def from_list(cls, v: Any) -> dict[str, Any]:
-        if isinstance(v, list):
-            return {"files": v}
-        return v
+	files: list[str]
 
-    @field_validator("files")
-    @classmethod
-    def exactly_two_paths(cls, v: list[str]) -> list[str]:
-        if len(v) != 2:
-            raise ValueError(
-                f"Each coupling pair must contain exactly two file paths. "
-                f"Got {len(v)}."
-            )
-        for path in v:
-            if not path.strip():
-                raise ValueError("File paths in coupling pairs must not be empty.")
-        return v
+	@model_validator(mode='before')
+	@classmethod
+	def from_list(cls, v: Any) -> dict[str, Any]:
+		if isinstance(v, list):
+			return {'files': v}
+		return v
+
+	@field_validator('files')
+	@classmethod
+	def exactly_two_paths(cls, v: list[str]) -> list[str]:
+		if len(v) != 2:
+			raise ValueError(
+				f'Each coupling pair must contain exactly two file paths. Got {len(v)}.'
+			)
+		for path in v:
+			if not path.strip():
+				raise ValueError('File paths in coupling pairs must not be empty.')
+		return v
 
 
 class Cluster(BaseModel):
-    id: int
-    summary: str
-    files: list[str]
-    coupling_pairs: list[CouplingPair]
+	id: int
+	summary: str
+	files: list[str]
+	coupling_pairs: list[CouplingPair]
 
-    @field_validator("summary")
-    @classmethod
-    def no_empty_summary(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("Cluster 'summary' must not be empty.")
-        return v
+	@field_validator('summary')
+	@classmethod
+	def no_empty_summary(cls, v: str) -> str:
+		if not v.strip():
+			raise ValueError("Cluster 'summary' must not be empty.")
+		return v
 
-    @field_validator("files")
-    @classmethod
-    def files_not_empty_strings(cls, v: list[str]) -> list[str]:
-        for path in v:
-            if not path.strip():
-                raise ValueError("File paths in cluster 'files' must not be empty.")
-        return v
+	@field_validator('files')
+	@classmethod
+	def files_not_empty_strings(cls, v: list[str]) -> list[str]:
+		for path in v:
+			if not path.strip():
+				raise ValueError("File paths in cluster 'files' must not be empty.")
+		return v
 
 
 class SummaryOutput(BaseModel):
-    repo_name: str
-    generated_at: str
-    what_it_does: str
-    read_first: list[ReadFirstEntry]
-    stable: list[FileNote]
-    hotspots: list[FileNote]
-    clusters: list[Cluster]
+	repo_name: str
+	generated_at: str
+	what_it_does: str
+	read_first: list[ReadFirstEntry]
+	stable: list[FileNote]
+	hotspots: list[FileNote]
+	clusters: list[Cluster]
 
-    @field_validator("repo_name", "what_it_does")
-    @classmethod
-    def no_empty_strings(cls, v: str, info: Any) -> str:
-        if not v.strip():
-            raise ValueError(f"Field '{info.field_name}' must not be empty.")
-        return v
+	@field_validator('repo_name', 'what_it_does')
+	@classmethod
+	def no_empty_strings(cls, v: str, info: Any) -> str:
+		if not v.strip():
+			raise ValueError(f"Field '{info.field_name}' must not be empty.")
+		return v
 
-    @field_validator("generated_at")
-    @classmethod
-    def valid_iso_timestamp(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("Field 'generated_at' must not be empty.")
-        try:
-            datetime.fromisoformat(v.replace("Z", "+00:00"))
-        except ValueError:
-            raise ValueError(
-                f"Field 'generated_at' must be a valid ISO 8601 timestamp. "
-                f"Got: '{v}'."
-            )
-        return v
+	@field_validator('generated_at')
+	@classmethod
+	def valid_iso_timestamp(cls, v: str) -> str:
+		if not v.strip():
+			raise ValueError("Field 'generated_at' must not be empty.")
+		try:
+			datetime.fromisoformat(v.replace('Z', '+00:00'))
+		except ValueError:
+			raise ValueError(
+				f"Field 'generated_at' must be a valid ISO 8601 timestamp. Got: '{v}'."
+			)
+		return v
 
 
 # ---------------------------------------------------------------------------
 # Validation result
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ValidationResult:
-    valid: bool
-    errors: list[str] = field(default_factory=list)
+	valid: bool
+	errors: list[str] = field(default_factory=list)
 
-    def __bool__(self) -> bool:
-        return self.valid
+	def __bool__(self) -> bool:
+		return self.valid
 
 
 # ---------------------------------------------------------------------------
 # Public interface
 # ---------------------------------------------------------------------------
 
+
 def validate_summary(data: dict[str, Any]) -> ValidationResult:
-    """
-    Validate a parsed summary.json dict against the locked Compass schema.
+	"""
+	Validate a parsed summary.json dict against the locked Compass schema.
 
-    All list fields (read_first, stable, hotspots, clusters) are required
-    but may be empty arrays. No field may be omitted.
+	All list fields (read_first, stable, hotspots, clusters) are required
+	but may be empty arrays. No field may be omitted.
 
-    Args:
-        data: The result of json.loads() on a summary.json file.
+	Args:
+	    data: The result of json.loads() on a summary.json file.
 
-    Returns:
-        ValidationResult with valid=True and empty errors list on success,
-        or valid=False with a list of human-readable error messages on failure.
+	Returns:
+	    ValidationResult with valid=True and empty errors list on success,
+	    or valid=False with a list of human-readable error messages on failure.
 
-    Example:
-        import json
-        from compass.schemas.summary_schema import validate_summary
+	Example:
+	    import json
+	    from compass.schemas.summary_schema import validate_summary
 
-        with open(".compass/output/summary.json") as f:
-            data = json.load(f)
+	    with open(".compass/output/summary.json") as f:
+	        data = json.load(f)
 
-        result = validate_summary(data)
-        if not result.valid:
-            for error in result.errors:
-                print(f"  - {error}")
-    """
-    try:
-        SummaryOutput.model_validate(data)
-        return ValidationResult(valid=True)
-    except Exception as exc:
-        errors = _extract_errors(exc)
-        return ValidationResult(valid=False, errors=errors)
+	    result = validate_summary(data)
+	    if not result.valid:
+	        for error in result.errors:
+	            print(f"  - {error}")
+	"""
+	try:
+		SummaryOutput.model_validate(data)
+		return ValidationResult(valid=True)
+	except Exception as exc:
+		errors = _extract_errors(exc)
+		return ValidationResult(valid=False, errors=errors)
 
 
 def _extract_errors(exc: Exception) -> list[str]:
-    """
-    Convert a pydantic ValidationError into a flat list of readable strings.
-    Each string names the location in the document and what went wrong.
-    """
-    from pydantic import ValidationError
+	"""
+	Convert a pydantic ValidationError into a flat list of readable strings.
+	Each string names the location in the document and what went wrong.
+	"""
+	from pydantic import ValidationError
 
-    if not isinstance(exc, ValidationError):
-        return [str(exc)]
+	if not isinstance(exc, ValidationError):
+		return [str(exc)]
 
-    errors: list[str] = []
-    for error in exc.errors():
-        location = " → ".join(str(part) for part in error["loc"]) if error["loc"] else "root"
-        message = error["msg"]
-        errors.append(f"{location}: {message}")
-    return errors
+	errors: list[str] = []
+	for error in exc.errors():
+		location = ' → '.join(str(part) for part in error['loc']) if error['loc'] else 'root'
+		message = error['msg']
+		errors.append(f'{location}: {message}')
+	return errors


### PR DESCRIPTION
## Summary

Applies ruff formatting to `compass/schemas/rules_schema.py` and `compass/schemas/summary_schema.py`, which were merged in PR #28 without passing the Ruff CI check.

This is the root cause of the Ruff failures on PR #35 and PR #36. Once merged, both PRs should go green on Ruff.

## Changes

- `compass/schemas/rules_schema.py` — ruff formatting applied
- `compass/schemas/summary_schema.py` — ruff formatting applied

No logic changes.