### PR TITLE
feat(collectors): add ImportGraphCollector and fix frozen dataclass fields

### DIFF
--- a/compass/collectors/ast_grep.py
+++ b/compass/collectors/ast_grep.py
@@ -40,7 +40,8 @@ class AstGrepCollector(BaseCollector[dict[str, list[str]]]):
 				stdout, stderr = await proc.communicate()
 				if proc.returncode != 0:
 					raise CollectorError(
-						'ast-grep failed or is not installed. Run: brew install ast-grep'
+						'AstGrepCollector',
+						'ast-grep failed or is not installed. Run: brew install ast-grep',
 					)
 
 				output = stdout.decode()

--- a/compass/collectors/ast_grep.py
+++ b/compass/collectors/ast_grep.py
@@ -6,45 +6,45 @@ from compass.collectors.base import BaseCollector
 from compass.errors import CollectorError
 
 PATTERNS: dict[str, list[tuple[str, str]]] = {
-    "error_handling": [
-        ("except $_ as $_:", "python"),
-        ("except $_:", "python"),
-    ],
-    "decorators": [
-        ("@$DECORATOR", "python"),
-    ],
-    "naming": [
-        ("def $NAME($$$)", "python"),
-        ("class $NAME($$$)", "python"),
-    ],
+	'error_handling': [
+		('except $_ as $_:', 'python'),
+		('except $_:', 'python'),
+	],
+	'decorators': [
+		('@$DECORATOR', 'python'),
+	],
+	'naming': [
+		('def $NAME($$$)', 'python'),
+		('class $NAME($$$)', 'python'),
+	],
 }
 
 
 class AstGrepCollector(BaseCollector[dict[str, list[str]]]):
-    async def collect(self, target_path: Path) -> dict[str, list[str]]:
-        results: dict[str, list[str]] = {key: [] for key in PATTERNS}
+	async def collect(self, target_path: Path) -> dict[str, list[str]]:
+		results: dict[str, list[str]] = {key: [] for key in PATTERNS}
 
-        for category, patterns in PATTERNS.items():
-            for pattern, lang in patterns:
-                proc = await asyncio.create_subprocess_exec(
-                    "ast-grep",
-                    "--pattern",
-                    pattern,
-                    "--lang",
-                    lang,
-                    "--json",
-                    str(target_path),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                stdout, stderr = await proc.communicate()
-                if proc.returncode != 0:
-                    raise CollectorError(
-                        "ast-grep failed or is not installed. Run: brew install ast-grep"
-                    )
+		for category, patterns in PATTERNS.items():
+			for pattern, lang in patterns:
+				proc = await asyncio.create_subprocess_exec(
+					'ast-grep',
+					'--pattern',
+					pattern,
+					'--lang',
+					lang,
+					'--json',
+					str(target_path),
+					stdout=asyncio.subprocess.PIPE,
+					stderr=asyncio.subprocess.PIPE,
+				)
+				stdout, stderr = await proc.communicate()
+				if proc.returncode != 0:
+					raise CollectorError(
+						'ast-grep failed or is not installed. Run: brew install ast-grep'
+					)
 
-                output = stdout.decode()
-                data = json.loads(output)
-                for item in data:
-                    results[category].append(item["text"])
-        return results
+				output = stdout.decode()
+				data = json.loads(output)
+				for item in data:
+					results[category].append(item['text'])
+		return results

--- a/compass/collectors/base.py
+++ b/compass/collectors/base.py
@@ -2,9 +2,9 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Generic, TypeVar
 
-T = TypeVar("T")
+T = TypeVar('T')
 
 
 class BaseCollector(ABC, Generic[T]):
-    @abstractmethod
-    async def collect(self, target_path: Path) -> T: ...
+	@abstractmethod
+	async def collect(self, target_path: Path) -> T: ...

--- a/compass/collectors/docs_reader.py
+++ b/compass/collectors/docs_reader.py
@@ -5,22 +5,22 @@ from compass.errors import CollectorError
 
 
 class DocsReaderCollector(BaseCollector[dict[str, str]]):
-    async def collect(self, target_path: Path) -> dict[str, str]:
-        results: dict[str, str] = {}
+	async def collect(self, target_path: Path) -> dict[str, str]:
+		results: dict[str, str] = {}
 
-        candidates = [
-            target_path / "CONTRIBUTING.md",
-            target_path / "README.md",
-            target_path / ".cursor" / "rules",
-        ]
-        adr_dir = target_path / "docs" / "adr"
-        if adr_dir.exists():
-            candidates.extend(adr_dir.iterdir())
+		candidates = [
+			target_path / 'CONTRIBUTING.md',
+			target_path / 'README.md',
+			target_path / '.cursor' / 'rules',
+		]
+		adr_dir = target_path / 'docs' / 'adr'
+		if adr_dir.exists():
+			candidates.extend(adr_dir.iterdir())
 
-        for path in candidates:
-            if path.exists():
-                try:
-                    results[str(path.relative_to(target_path))] = path.read_text()
-                except OSError as e:
-                    raise CollectorError(f"Failed to read {path}: {e}")
-        return results
+		for path in candidates:
+			if path.exists():
+				try:
+					results[str(path.relative_to(target_path))] = path.read_text()
+				except OSError as e:
+					raise CollectorError('DocsReaderCollector', f'Failed to read {path}: {e}')
+		return results

--- a/compass/collectors/git_log.py
+++ b/compass/collectors/git_log.py
@@ -12,128 +12,124 @@ from compass.errors import CollectorError
 
 @dataclass
 class FileGitData:
-    churn: float
-    age: int
-    coupling_pairs: list[str]
+	churn: float
+	age: int
+	coupling_pairs: list[str]
 
 
 @dataclass
 class GitLogResult:
-    file_data: dict[str, FileGitData]
-    coupling_pairs: list[CouplingPair]
-    git_patterns: GitPatternsSnapshot
+	file_data: dict[str, FileGitData]
+	coupling_pairs: list[CouplingPair]
+	git_patterns: GitPatternsSnapshot
 
 
 class GitLogCollector(BaseCollector[GitLogResult]):
-    async def collect(self, target_path: Path) -> GitLogResult:
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "log",
-            "--name-only",
-            "--format=COMMIT %H",
-            cwd=target_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await proc.communicate()
-        output = stdout.decode()
+	async def collect(self, target_path: Path) -> GitLogResult:
+		proc = await asyncio.create_subprocess_exec(
+			'git',
+			'log',
+			'--name-only',
+			'--format=COMMIT %H',
+			cwd=target_path,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		stdout, stderr = await proc.communicate()
+		output = stdout.decode()
 
-        if proc.returncode != 0:
-            raise CollectorError("GitLogCollector", f"{target_path} is not a git repository")
+		if proc.returncode != 0:
+			raise CollectorError('GitLogCollector', f'{target_path} is not a git repository')
 
-        commits = {}
-        commit_hash = None
-        for line in output.strip().split("\n"):
-            if line.startswith("COMMIT"):
-                commit_hash = line.strip().split(" ")[1]
-                commits[commit_hash] = []
-            elif line.strip() == "":
-                continue
-            elif commit_hash is not None:
-                commits[commit_hash].append(line)
+		commits = {}
+		commit_hash = None
+		for line in output.strip().split('\n'):
+			if line.startswith('COMMIT'):
+				commit_hash = line.strip().split(' ')[1]
+				commits[commit_hash] = []
+			elif line.strip() == '':
+				continue
+			elif commit_hash is not None:
+				commits[commit_hash].append(line)
 
-        file_counter = {}
-        for list_of_files in commits.values():
-            for file in list_of_files:
-                file_counter[file] = file_counter.get(file, 0) + 1
+		file_counter = {}
+		for list_of_files in commits.values():
+			for file in list_of_files:
+				file_counter[file] = file_counter.get(file, 0) + 1
 
-        max_count = max(file_counter.values()) if file_counter else 1
+		max_count = max(file_counter.values()) if file_counter else 1
 
-        churn = {}
-        for file_name, file_count in file_counter.items():
-            churn_rate = file_count / max_count
-            churn[file_name] = churn_rate
+		churn = {}
+		for file_name, file_count in file_counter.items():
+			churn_rate = file_count / max_count
+			churn[file_name] = churn_rate
 
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "log",
-            "--name-only",
-            "--format=COMMIT %ct",
-            cwd=target_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await proc.communicate()
-        output = stdout.decode()
+		proc = await asyncio.create_subprocess_exec(
+			'git',
+			'log',
+			'--name-only',
+			'--format=COMMIT %ct',
+			cwd=target_path,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		stdout, stderr = await proc.communicate()
+		output = stdout.decode()
 
-        if proc.returncode != 0:
-            raise CollectorError("GitLogCollector", f"{target_path} is not a git repository")
+		if proc.returncode != 0:
+			raise CollectorError('GitLogCollector', f'{target_path} is not a git repository')
 
-        age = {}
-        now = datetime.now(timezone.utc).timestamp()
-        timestamp = 0
-        for line in output.strip().split("\n"):
-            if line.startswith("COMMIT"):
-                timestamp = line.strip().split(" ")[1]
-            elif line.strip() == "":
-                continue
-            elif line not in age:
-                age[line] = int((now - float(timestamp)) / 86400)
+		age = {}
+		now = datetime.now(timezone.utc).timestamp()
+		timestamp = 0
+		for line in output.strip().split('\n'):
+			if line.startswith('COMMIT'):
+				timestamp = line.strip().split(' ')[1]
+			elif line.strip() == '':
+				continue
+			elif line not in age:
+				age[line] = int((now - float(timestamp)) / 86400)
 
-        coupling_pairs = {}
-        for files in commits.values():
-            for file_a, file_b in combinations(files, 2):
-                key = tuple(sorted([file_a, file_b]))
-                coupling_pairs[key] = coupling_pairs.get(key, 0) + 1
+		coupling_pairs = {}
+		for files in commits.values():
+			for file_a, file_b in combinations(files, 2):
+				key = tuple(sorted([file_a, file_b]))
+				coupling_pairs[key] = coupling_pairs.get(key, 0) + 1
 
-        coupling_pairs_list = [
-            CouplingPair(file_a=file_a, file_b=file_b, degree=degree)
-            for (file_a, file_b), degree in coupling_pairs.items()
-        ]
+		coupling_pairs_list = [
+			CouplingPair(file_a=file_a, file_b=file_b, degree=degree)
+			for (file_a, file_b), degree in coupling_pairs.items()
+		]
 
-        file_coupling: dict[str, list[str]] = {}
-        for file_a, file_b in coupling_pairs.keys():
-            file_coupling.setdefault(file_a, []).append(file_b)
-            file_coupling.setdefault(file_b, []).append(file_a)
+		file_coupling: dict[str, list[str]] = {}
+		for file_a, file_b in coupling_pairs.keys():
+			file_coupling.setdefault(file_a, []).append(file_b)
+			file_coupling.setdefault(file_b, []).append(file_a)
 
-        file_data: dict[str, FileGitData] = {}
-        for file in file_counter.keys():
-            file_churn = churn[file]
-            file_age = age.get(file, 0)
-            file_pairs = file_coupling.get(file, [])
-            file_data[file] = FileGitData(
-                churn=file_churn, age=file_age, coupling_pairs=file_pairs
-            )
+		file_data: dict[str, FileGitData] = {}
+		for file in file_counter.keys():
+			file_churn = churn[file]
+			file_age = age.get(file, 0)
+			file_pairs = file_coupling.get(file, [])
+			file_data[file] = FileGitData(churn=file_churn, age=file_age, coupling_pairs=file_pairs)
 
-        sorted_by_churn = sorted(churn.items(), key=lambda x: x[1], reverse=True)
-        hotspots = [f for f, _ in sorted_by_churn[:10]]
-        stable_files = [f for f, _ in sorted_by_churn[-10:]]
+		sorted_by_churn = sorted(churn.items(), key=lambda x: x[1], reverse=True)
+		hotspots = [f for f, _ in sorted_by_churn[:10]]
+		stable_files = [f for f, _ in sorted_by_churn[-10:]]
 
-        coupling_clusters = [
-            list(cluster)
-            for cluster in {
-                frozenset([p.file_a, p.file_b]) for p in coupling_pairs_list
-            }
-        ]
+		coupling_clusters = [
+			list(cluster)
+			for cluster in {frozenset([p.file_a, p.file_b]) for p in coupling_pairs_list}
+		]
 
-        git_patterns = GitPatternsSnapshot(
-            hotspots=hotspots,
-            stable_files=stable_files,
-            coupling_clusters=coupling_clusters,
-        )
+		git_patterns = GitPatternsSnapshot(
+			hotspots=hotspots,
+			stable_files=stable_files,
+			coupling_clusters=coupling_clusters,
+		)
 
-        return GitLogResult(
-            file_data=file_data,
-            coupling_pairs=coupling_pairs_list,
-            git_patterns=git_patterns,
-        )
+		return GitLogResult(
+			file_data=file_data,
+			coupling_pairs=coupling_pairs_list,
+			git_patterns=git_patterns,
+		)

--- a/compass/collectors/import_graph.py
+++ b/compass/collectors/import_graph.py
@@ -1,0 +1,55 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import TextContent
+
+from compass.collectors.base import BaseCollector
+from compass.domain.cluster import Cluster
+from compass.errors import CollectorError
+
+
+@dataclass
+class ImportGraphResult:
+	centrality: dict[str, float]
+	cluster_id: dict[str, int]
+	clusters: list[Cluster]
+
+
+class ImportGraphCollector(BaseCollector[ImportGraphResult]):
+	async def collect(self, target_path: Path) -> ImportGraphResult:
+		mcp_binary_path = Path.home() / '.compass' / 'bin' / 'codebase-memory-mcp'
+
+		if not mcp_binary_path.exists():
+			raise CollectorError('ImportGraphCollector', f'{mcp_binary_path} does not exist.')
+
+		server_params = StdioServerParameters(
+			command=str(mcp_binary_path),
+			args=[str(target_path)],
+		)
+
+		async with stdio_client(server_params) as (read, write):
+			async with ClientSession(read, write) as session:
+				await session.initialize()
+
+				result = await session.call_tool(
+					'search_graph',
+					{
+						'project': str(target_path),
+						'label': 'File',
+					},
+				)
+
+				if not result.content or not isinstance(result.content[0], TextContent):
+					raise CollectorError(
+						'ImportGraphCollector', 'unexpected response from codebase-memory-mcp'
+					)
+
+				data = json.loads(result.content[0].text)
+				nodes = data.get('results', [])
+
+				max_degree = max(
+					(node['in_degree'] + node['out_degree'] for node in nodes), default=1
+				)

--- a/compass/collectors/import_graph.py
+++ b/compass/collectors/import_graph.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -34,22 +35,85 @@ class ImportGraphCollector(BaseCollector[ImportGraphResult]):
 			async with ClientSession(read, write) as session:
 				await session.initialize()
 
-				result = await session.call_tool(
-					'search_graph',
+				# centrality: in-degree per file
+				centrality_result = await session.call_tool(
+					'query_graph',
 					{
-						'project': str(target_path),
-						'label': 'File',
+						'query': '''
+							MATCH (importer:File)-[:IMPORTS]->(imported:File)
+							RETURN imported.file_path AS file_path, COUNT(importer) AS in_degree
+							ORDER BY in_degree DESC
+						''',
 					},
 				)
-
-				if not result.content or not isinstance(result.content[0], TextContent):
+				if not centrality_result.content or not isinstance(
+					centrality_result.content[0], TextContent
+				):
 					raise CollectorError(
-						'ImportGraphCollector', 'unexpected response from codebase-memory-mcp'
+						'ImportGraphCollector',
+						'unexpected response from codebase-memory-mcp (centrality)',
 					)
 
-				data = json.loads(result.content[0].text)
-				nodes = data.get('results', [])
+				rows = json.loads(centrality_result.content[0].text).get('results', [])
+				max_degree = max((row['in_degree'] for row in rows), default=1)
+				centrality = {
+					row['file_path']: row['in_degree'] / max_degree
+					for row in rows
+				}
 
-				max_degree = max(
-					(node['in_degree'] + node['out_degree'] for node in nodes), default=1
+				# clusters: connected components via union-find on import edges
+				edge_result = await session.call_tool(
+					'query_graph',
+					{
+						'query': '''
+							MATCH (a:File)-[:IMPORTS]->(b:File)
+							RETURN a.file_path AS source, b.file_path AS target
+						''',
+					},
+				)
+				if not edge_result.content or not isinstance(
+					edge_result.content[0], TextContent
+				):
+					raise CollectorError(
+						'ImportGraphCollector',
+						'unexpected response from codebase-memory-mcp (edges)',
+					)
+
+				edge_rows = json.loads(edge_result.content[0].text).get('results', [])
+
+				parent: dict[str, str] = {}
+
+				def find(x: str) -> str:
+					parent.setdefault(x, x)
+					if parent[x] != x:
+						parent[x] = find(parent[x])
+					return parent[x]
+
+				def union(x: str, y: str) -> None:
+					parent[find(x)] = find(y)
+
+				for row in edge_rows:
+					union(row['source'], row['target'])
+
+				root_to_id: dict[str, int] = {}
+				cluster_id: dict[str, int] = {}
+				for path in parent:
+					root = find(path)
+					if root not in root_to_id:
+						root_to_id[root] = len(root_to_id)
+					cluster_id[path] = root_to_id[root]
+
+				cluster_files: dict[int, list[str]] = defaultdict(list)
+				for path, cid in cluster_id.items():
+					cluster_files[cid].append(path)
+
+				clusters = [
+					Cluster(id=cid, files=tuple(files))
+					for cid, files in cluster_files.items()
+				]
+
+				return ImportGraphResult(
+					centrality=centrality,
+					cluster_id=cluster_id,
+					clusters=clusters,
 				)

--- a/compass/collectors/orchestrator.py
+++ b/compass/collectors/orchestrator.py
@@ -1,1 +1,0 @@
-import asyncio

--- a/compass/domain/cluster.py
+++ b/compass/domain/cluster.py
@@ -4,4 +4,4 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Cluster:
 	id: int
-	files: list[str]
+	files: tuple[str, ...]

--- a/compass/domain/file_score.py
+++ b/compass/domain/file_score.py
@@ -8,4 +8,4 @@ class FileScore:
 	age: int
 	centrality: float
 	cluster_id: int
-	coupling_pairs: list[str]
+	coupling_pairs: tuple[str, ...]

--- a/tests/unit/test_ast_grep_collector.py
+++ b/tests/unit/test_ast_grep_collector.py
@@ -8,31 +8,31 @@ from compass.errors import CollectorError
 
 
 async def test_ast_grep_collector_happy_path(tmp_path):
-    fake_output = json.dumps([{"text": "except ValueError as e:"}]).encode()
+	fake_output = json.dumps([{'text': 'except ValueError as e:'}]).encode()
 
-    mock_proc = AsyncMock()
-    mock_proc.returncode = 0
-    mock_proc.communicate = AsyncMock(return_value=(fake_output, b""))
+	mock_proc = AsyncMock()
+	mock_proc.returncode = 0
+	mock_proc.communicate = AsyncMock(return_value=(fake_output, b''))
 
-    with patch(
-        "compass.collectors.ast_grep.asyncio.create_subprocess_exec",
-        return_value=mock_proc,
-    ):
-        collector = AstGrepCollector()
-        result = await collector.collect(tmp_path)
+	with patch(
+		'compass.collectors.ast_grep.asyncio.create_subprocess_exec',
+		return_value=mock_proc,
+	):
+		collector = AstGrepCollector()
+		result = await collector.collect(tmp_path)
 
-    assert "except ValueError as e:" in result["error_handling"]
+	assert 'except ValueError as e:' in result['error_handling']
 
 
 async def test_ast_grep_collector_raises_on_failure(tmp_path):
-    mock_proc = AsyncMock()
-    mock_proc.returncode = 1
-    mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
+	mock_proc = AsyncMock()
+	mock_proc.returncode = 1
+	mock_proc.communicate = AsyncMock(return_value=(b'', b'error'))
 
-    with patch(
-        "compass.collectors.ast_grep.asyncio.create_subprocess_exec",
-        return_value=mock_proc,
-    ):
-        collector = AstGrepCollector()
-        with pytest.raises(CollectorError):
-            await collector.collect(tmp_path)
+	with patch(
+		'compass.collectors.ast_grep.asyncio.create_subprocess_exec',
+		return_value=mock_proc,
+	):
+		collector = AstGrepCollector()
+		with pytest.raises(CollectorError):
+			await collector.collect(tmp_path)

--- a/tests/unit/test_docs_reader_collector.py
+++ b/tests/unit/test_docs_reader_collector.py
@@ -5,22 +5,22 @@ from compass.errors import CollectorError
 
 
 async def test_docs_reader_finds_contributing(tmp_path):
-    contributing = tmp_path / "CONTRIBUTING.md"
-    contributing.write_text("# Contributing")
+	contributing = tmp_path / 'CONTRIBUTING.md'
+	contributing.write_text('# Contributing')
 
-    collector = DocsReaderCollector()
-    result = await collector.collect(tmp_path)
+	collector = DocsReaderCollector()
+	result = await collector.collect(tmp_path)
 
-    assert result["CONTRIBUTING.md"] == "# Contributing"
+	assert result['CONTRIBUTING.md'] == '# Contributing'
 
 
 async def test_docs_reader_raises_on_read_error(tmp_path):
-    contributing = tmp_path / "CONTRIBUTING.md"
-    contributing.write_text("# Contributing")
+	contributing = tmp_path / 'CONTRIBUTING.md'
+	contributing.write_text('# Contributing')
 
-    with patch.object(
-        contributing.__class__, "read_text", side_effect=OSError("permission denied")
-    ):
-        collector = DocsReaderCollector()
-        with pytest.raises(CollectorError):
-            await collector.collect(tmp_path)
+	with patch.object(
+		contributing.__class__, 'read_text', side_effect=OSError('permission denied')
+	):
+		collector = DocsReaderCollector()
+		with pytest.raises(CollectorError):
+			await collector.collect(tmp_path)

--- a/tests/unit/test_domain_models.py
+++ b/tests/unit/test_domain_models.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 import dacite
+from dacite import Config
 import pytest
 
 from compass.domain.adapter_output import AdapterOutput
@@ -98,7 +99,7 @@ def test_adapter_output_fields():
 def test_analysis_context_deserialization():
 	json_path = Path(__file__).parent.parent.parent / 'examples' / 'analysis_context.json'
 	data = json.loads(json_path.read_text())
-	context = dacite.from_dict(AnalysisContext, data)
+	context = dacite.from_dict(AnalysisContext, data, config=Config(cast=[tuple]))
 	assert isinstance(context, AnalysisContext)
 	assert isinstance(context.architecture, ArchitectureSnapshot)
 	assert isinstance(context.architecture.file_scores[0], FileScore)
@@ -109,7 +110,7 @@ def test_analysis_context_deserialization():
 def test_analysis_context_serialization_roundtrip():
 	json_path = Path(__file__).parent.parent.parent / 'examples' / 'analysis_context.json'
 	data = json.loads(json_path.read_text())
-	context = dacite.from_dict(AnalysisContext, data)
+	context = dacite.from_dict(AnalysisContext, data, config=Config(cast=[tuple]))
 	serialized = dataclasses.asdict(context)
 	assert (
 		serialized['architecture']['file_scores'][0]['path']

--- a/tests/unit/test_git_log_collector.py
+++ b/tests/unit/test_git_log_collector.py
@@ -1,4 +1,3 @@
-
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -9,35 +8,41 @@ from compass.errors import CollectorError
 
 
 async def test_happy_path():
-    commits_output = "COMMIT abc123\nsrc/app.py\nsrc/config.py\n\nCOMMIT def456\nsrc/app.py"
-    timestamps_output = "COMMIT 1700000000\nsrc/app.py\nsrc/config.py\n\nCOMMIT 1699000000\nsrc/app.py"
+	commits_output = 'COMMIT abc123\nsrc/app.py\nsrc/config.py\n\nCOMMIT def456\nsrc/app.py'
+	timestamps_output = (
+		'COMMIT 1700000000\nsrc/app.py\nsrc/config.py\n\nCOMMIT 1699000000\nsrc/app.py'
+	)
 
-    def make_proc(stdout: str):
-        proc = AsyncMock()
-        proc.returncode = 0
-        proc.communicate.return_value = (stdout.encode(), b"")
-        return proc
+	def make_proc(stdout: str):
+		proc = AsyncMock()
+		proc.returncode = 0
+		proc.communicate.return_value = (stdout.encode(), b'')
+		return proc
 
-    with patch("compass.collectors.git_log.asyncio.create_subprocess_exec",
-        side_effect = [make_proc(commits_output), make_proc(timestamps_output)],
-    ):
+	with patch(
+		'compass.collectors.git_log.asyncio.create_subprocess_exec',
+		side_effect=[make_proc(commits_output), make_proc(timestamps_output)],
+	):
+		collector = GitLogCollector()
+		result = await collector.collect(Path('/fake/repo'))
 
-        collector = GitLogCollector()
-        result = await collector.collect(Path("/fake/repo"))
+		assert result.file_data['src/app.py'].churn == 1.0
+		assert result.file_data['src/config.py'].churn == 0.5
+		assert 'src/config.py' in result.file_data['src/app.py'].coupling_pairs
+		assert (
+			result.file_data['src/app.py'].age >= 0
+		)  # Exact value us relative to "now", so only checks for positive integer
 
-        assert result.file_data["src/app.py"].churn == 1.0
-        assert result.file_data["src/config.py"].churn == 0.5
-        assert "src/config.py" in result.file_data["src/app.py"].coupling_pairs
-        assert result.file_data["src/app.py"].age >= 0 # Exact value us relative to "now", so only checks for positive integer
 
 async def test_failure_path():
 
-    mock_proc = AsyncMock()
-    mock_proc.returncode = 1
-    mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
-    with patch("compass.collectors.git_log.asyncio.create_subprocess_exec",
-        return_value = mock_proc,
-    ):
-        collector = GitLogCollector()
-        with pytest.raises(CollectorError):
-            await collector.collect(Path("/fake/repo"))
+	mock_proc = AsyncMock()
+	mock_proc.returncode = 1
+	mock_proc.communicate = AsyncMock(return_value=(b'', b'error'))
+	with patch(
+		'compass.collectors.git_log.asyncio.create_subprocess_exec',
+		return_value=mock_proc,
+	):
+		collector = GitLogCollector()
+		with pytest.raises(CollectorError):
+			await collector.collect(Path('/fake/repo'))


### PR DESCRIPTION
## Summary
- Add ImportGraphCollector using MCP Python SDK to compute file centrality (in-degree) and connected-component clusters via Cypher queries against codebase-memory-mcp
- Fix Cluster.files and FileScore.coupling_pairs from list[str] to tuple[str, ...] to be compatible with frozen=True dataclasses
- Fix CollectorError call in AstGrepCollector to match new two-argument signature

## Test plan
- [ ] Unit tests follow in a separate PR
