### PR TITLE
test(collectors): add unit tests for ImportGraphCollector

### DIFF
--- a/compass/collectors/import_graph.py
+++ b/compass/collectors/import_graph.py
@@ -38,9 +38,7 @@ class ImportGraphCollector(BaseCollector[ImportGraphResult]):
 				projects_result = await session.call_tool('list_projects', {})
 				if isinstance(projects_result.content[0], TextContent):
 					projects = json.loads(projects_result.content[0].text).get('projects', [])
-					already_indexed = any(
-						p.get('root_path') == str(target_path) for p in projects
-					)
+					already_indexed = any(p.get('root_path') == str(target_path) for p in projects)
 				else:
 					already_indexed = False
 

--- a/compass/collectors/import_graph.py
+++ b/compass/collectors/import_graph.py
@@ -39,11 +39,11 @@ class ImportGraphCollector(BaseCollector[ImportGraphResult]):
 				centrality_result = await session.call_tool(
 					'query_graph',
 					{
-						'query': '''
+						'query': """
 							MATCH (importer:File)-[:IMPORTS]->(imported:File)
 							RETURN imported.file_path AS file_path, COUNT(importer) AS in_degree
 							ORDER BY in_degree DESC
-						''',
+						""",
 					},
 				)
 				if not centrality_result.content or not isinstance(
@@ -56,24 +56,19 @@ class ImportGraphCollector(BaseCollector[ImportGraphResult]):
 
 				rows = json.loads(centrality_result.content[0].text).get('results', [])
 				max_degree = max((row['in_degree'] for row in rows), default=1)
-				centrality = {
-					row['file_path']: row['in_degree'] / max_degree
-					for row in rows
-				}
+				centrality = {row['file_path']: row['in_degree'] / max_degree for row in rows}
 
 				# clusters: connected components via union-find on import edges
 				edge_result = await session.call_tool(
 					'query_graph',
 					{
-						'query': '''
+						'query': """
 							MATCH (a:File)-[:IMPORTS]->(b:File)
 							RETURN a.file_path AS source, b.file_path AS target
-						''',
+						""",
 					},
 				)
-				if not edge_result.content or not isinstance(
-					edge_result.content[0], TextContent
-				):
+				if not edge_result.content or not isinstance(edge_result.content[0], TextContent):
 					raise CollectorError(
 						'ImportGraphCollector',
 						'unexpected response from codebase-memory-mcp (edges)',
@@ -108,8 +103,7 @@ class ImportGraphCollector(BaseCollector[ImportGraphResult]):
 					cluster_files[cid].append(path)
 
 				clusters = [
-					Cluster(id=cid, files=tuple(files))
-					for cid, files in cluster_files.items()
+					Cluster(id=cid, files=tuple(files)) for cid, files in cluster_files.items()
 				]
 
 				return ImportGraphResult(

--- a/tests/unit/test_import_graph_collector.py
+++ b/tests/unit/test_import_graph_collector.py
@@ -27,8 +27,8 @@ async def test_happy_path():
 	list_projects_output = {'projects': []}
 	mock_session = AsyncMock()
 	mock_session.call_tool.side_effect = [
-    	make_mcp_response(list_projects_output),   # list_projects
-        MagicMock(),
+		make_mcp_response(list_projects_output),  # list_projects
+		MagicMock(),
 		make_mcp_response(centrality_output),
 		make_mcp_response(edges_output),
 	]

--- a/tests/unit/test_import_graph_collector.py
+++ b/tests/unit/test_import_graph_collector.py
@@ -10,47 +10,50 @@ from compass.errors import CollectorError
 
 
 def make_mcp_response(data: dict) -> MagicMock:
-    content = TextContent(type='text', text=json.dumps(data))
-    result = MagicMock()
-    result.content = [content]
-    return result
+	content = TextContent(type='text', text=json.dumps(data))
+	result = MagicMock()
+	result.content = [content]
+	return result
 
 
 async def test_happy_path():
-    centrality_output = {
-    	'results': [
-    		{'file_path': 'src/app.py', 'in_degree': 3},
-    		{'file_path': 'src/config.py', 'in_degree': 1},
-    	]
-    }
-    edges_output = {'results': [{'source': 'src/app.py', 'target': 'src/config.py'}]}
+	centrality_output = {
+		'results': [
+			{'file_path': 'src/app.py', 'in_degree': 3},
+			{'file_path': 'src/config.py', 'in_degree': 1},
+		]
+	}
+	edges_output = {'results': [{'source': 'src/app.py', 'target': 'src/config.py'}]}
 
-    mock_session = AsyncMock()
-    mock_session.call_tool.side_effect = [
-        make_mcp_response(centrality_output),
-    	make_mcp_response(edges_output),
-    ]
+	mock_session = AsyncMock()
+	mock_session.call_tool.side_effect = [
+		make_mcp_response(centrality_output),
+		make_mcp_response(edges_output),
+	]
 
-    mock_cm = MagicMock()
-    mock_cm.__aenter__ = AsyncMock(return_value=(None, None))
-    mock_cm.__aexit__ = AsyncMock(return_value=None)
+	mock_cm = MagicMock()
+	mock_cm.__aenter__ = AsyncMock(return_value=(None, None))
+	mock_cm.__aexit__ = AsyncMock(return_value=None)
 
-    mock_client_session = MagicMock()
-    mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client_session.__aexit__ = AsyncMock(return_value=None)
+	mock_client_session = MagicMock()
+	mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
+	mock_client_session.__aexit__ = AsyncMock(return_value=None)
 
-    with patch('pathlib.Path.exists', return_value=True), \
-        patch('compass.collectors.import_graph.stdio_client', return_value=mock_cm), \
-        patch('compass.collectors.import_graph.ClientSession', return_value=mock_client_session):
-        collector = ImportGraphCollector()
-        result = await collector.collect(Path("/fake/repo"))
+	with (
+		patch('pathlib.Path.exists', return_value=True),
+		patch('compass.collectors.import_graph.stdio_client', return_value=mock_cm),
+		patch('compass.collectors.import_graph.ClientSession', return_value=mock_client_session),
+	):
+		collector = ImportGraphCollector()
+		result = await collector.collect(Path('/fake/repo'))
 
-    assert result.centrality['src/app.py'] == 1.0
-    assert result.centrality['src/config.py'] == pytest.approx(1/3)
-    assert 'src/app.py' in result.cluster_id
+	assert result.centrality['src/app.py'] == 1.0
+	assert result.centrality['src/config.py'] == pytest.approx(1 / 3)
+	assert 'src/app.py' in result.cluster_id
+
 
 async def test_failure_path():
-    with patch('pathlib.Path.exists', return_value=False):
-        collector = ImportGraphCollector()
-        with pytest.raises(CollectorError):
-            await collector.collect(Path("/fake/repo"))
+	with patch('pathlib.Path.exists', return_value=False):
+		collector = ImportGraphCollector()
+		with pytest.raises(CollectorError):
+			await collector.collect(Path('/fake/repo'))

--- a/tests/unit/test_import_graph_collector.py
+++ b/tests/unit/test_import_graph_collector.py
@@ -24,9 +24,11 @@ async def test_happy_path():
 		]
 	}
 	edges_output = {'results': [{'source': 'src/app.py', 'target': 'src/config.py'}]}
-
+	list_projects_output = {'projects': []}
 	mock_session = AsyncMock()
 	mock_session.call_tool.side_effect = [
+    	make_mcp_response(list_projects_output),   # list_projects
+        MagicMock(),
 		make_mcp_response(centrality_output),
 		make_mcp_response(edges_output),
 	]

--- a/tests/unit/test_import_graph_collector.py
+++ b/tests/unit/test_import_graph_collector.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp.types import TextContent
+
+from compass.collectors.import_graph import ImportGraphCollector
+from compass.errors import CollectorError
+
+
+def make_mcp_response(data: dict) -> MagicMock:
+    content = TextContent(type='text', text=json.dumps(data))
+    result = MagicMock()
+    result.content = [content]
+    return result
+
+
+async def test_happy_path():
+    centrality_output = {
+    	'results': [
+    		{'file_path': 'src/app.py', 'in_degree': 3},
+    		{'file_path': 'src/config.py', 'in_degree': 1},
+    	]
+    }
+    edges_output = {'results': [{'source': 'src/app.py', 'target': 'src/config.py'}]}
+
+    mock_session = AsyncMock()
+    mock_session.call_tool.side_effect = [
+        make_mcp_response(centrality_output),
+    	make_mcp_response(edges_output),
+    ]
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=(None, None))
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client_session = MagicMock()
+    mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_client_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch('pathlib.Path.exists', return_value=True), \
+        patch('compass.collectors.import_graph.stdio_client', return_value=mock_cm), \
+        patch('compass.collectors.import_graph.ClientSession', return_value=mock_client_session):
+        collector = ImportGraphCollector()
+        result = await collector.collect(Path("/fake/repo"))
+
+    assert result.centrality['src/app.py'] == 1.0
+    assert result.centrality['src/config.py'] == pytest.approx(1/3)
+    assert 'src/app.py' in result.cluster_id
+
+async def test_failure_path():
+    with patch('pathlib.Path.exists', return_value=False):
+        collector = ImportGraphCollector()
+        with pytest.raises(CollectorError):
+            await collector.collect(Path("/fake/repo"))


### PR DESCRIPTION
## Summary
- Add unit tests for ImportGraphCollector: happy path and failure path
- Both tests mock the MCP binary and session entirely

## Test plan
- [x] All unit tests pass: `pytest tests/unit/`
- [x] Happy path: centrality and cluster_id correctly computed from mocked MCP responses
- [x] Failure path: CollectorError raised when binary is missing
