### PR TITLE
chore(deps): add pydantic as runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "mcp",
   # Needed for .compass/config.yaml and ~/.compass/config.yaml parsing.
   "PyYAML>=6.0",
+  "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds `pydantic>=2.0` to `[project.dependencies]` in `pyproject.toml`
- `pydantic` is imported in `compass/schemas/rules_schema.py` and `compass/schemas/summary_schema.py` but was missing from the runtime deps

Closes #32

## Test plan
- [x] All 19 unit tests passing
- [x] ruff format and check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)