### PR TITLE
[Phase 2] Provider Layer + Adapter Infrastructure (#29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ruff
+          pip install -e ".[dev]"
 
       - name: Run Ruff (lint)
         run: |
@@ -33,7 +33,6 @@ jobs:
       - name: Run Ruff (format check)
         run: |
           ruff format --check .
-      # TODO: Make config file (pyproject.toml)
 
   type-check:
     name: Type Checking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev]"
+          pip install ruff
 
       - name: Run Ruff (lint)
         run: |
@@ -33,6 +33,7 @@ jobs:
       - name: Run Ruff (format check)
         run: |
           ruff format --check .
+      # TODO: Make config file (pyproject.toml)
 
   type-check:
     name: Type Checking

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ __pycache__/
 TODO.md
 CLAUDE.md
 .mcp.json
+
+.idea/
+COLLECTORS.md
+PROMPTS/
+docs/superpowers/

--- a/compass/adapters/base.py
+++ b/compass/adapters/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
@@ -10,13 +11,16 @@ from compass.paths import CompassPaths
 from compass.providers.base import BaseProvider, get_provider
 
 
-class AdapterBase:
+class AdapterBase(ABC):
 	name: str
 
 	def __init__(self, config: CompassConfig, paths: CompassPaths) -> None:
 		self._config = config
 		self._paths = paths
 		self._provider: BaseProvider = get_provider(config)
+
+	@abstractmethod
+	async def run(self) -> None: ...
 
 	def run_file_selector(self, criteria: dict[str, Any]) -> list[str]:
 		# Stubbed until issue #20 (FileSelector) is ready.

--- a/compass/adapters/base.py
+++ b/compass/adapters/base.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from compass.config import CompassConfig, VALIDATION_RETRY_DELAY
+from compass.errors import ProviderError, SchemaValidationError
+from compass.paths import CompassPaths
+from compass.providers.base import BaseProvider, get_provider
+
+
+class AdapterBase:
+	name: str
+
+	def __init__(self, config: CompassConfig, paths: CompassPaths) -> None:
+		self._config = config
+		self._paths = paths
+		self._provider: BaseProvider = get_provider(config)
+
+	def run_file_selector(self, criteria: dict[str, Any]) -> list[str]:
+		# Stubbed until issue #20 (FileSelector) is ready.
+		return []
+
+	async def run_grep_ast(self, files: list[str]) -> str:
+		if not files:
+			return ''
+		proc = await asyncio.create_subprocess_exec(
+			'grep-ast',
+			'--no-color',
+			*files,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		stdout, _ = await proc.communicate()
+		return stdout.decode()
+
+	async def call_provider(self, prompt: str) -> str:
+		try:
+			return await self._provider.call(prompt)
+		except RuntimeError as exc:
+			raise ProviderError(self.name, self._config.provider or 'unknown', str(exc)) from exc
+
+	async def validate_output(
+		self,
+		raw: str,
+		validator: Callable[[str], Any],
+		prompt: str,
+	) -> Any:
+		try:
+			return validator(raw)
+		except Exception as first_error:
+			await asyncio.sleep(VALIDATION_RETRY_DELAY)
+			retry_prompt = (
+				f'{prompt}\n\n'
+				f'Your previous response failed validation: {first_error}\n'
+				f'Please correct it and try again.'
+			)
+			retry_raw = await self.call_provider(retry_prompt)
+			try:
+				return validator(retry_raw)
+			except Exception as second_error:
+				raise SchemaValidationError(self.name, str(second_error)) from second_error

--- a/compass/adapters/orchestrator.py
+++ b/compass/adapters/orchestrator.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from compass.adapters.base import AdapterBase
+from compass.config import CompassConfig
+from compass.errors import AdapterError
+from compass.log import get_logger
+from compass.paths import compass_paths
+
+log = get_logger(__name__)
+
+# Populated as concrete adapters are implemented (issues #30, #31).
+ADAPTER_REGISTRY: dict[str, type[AdapterBase]] = {}
+
+
+class Orchestrator:
+	def __init__(self, config: CompassConfig) -> None:
+		self._config = config
+		self._paths = compass_paths(config.target_path)
+
+	async def run(self) -> None:
+		for adapter_name in self._config.adapters:
+			cls = ADAPTER_REGISTRY.get(adapter_name)
+			if cls is None:
+				log.warning('[%s] unknown adapter — skipping', adapter_name)
+				continue
+			adapter = cls(self._config, self._paths)
+			try:
+				await adapter.run()
+			except AdapterError as exc:
+				log.error('[%s] failed — %s', adapter_name, exc)

--- a/compass/collectors/orchestrator.py
+++ b/compass/collectors/orchestrator.py
@@ -8,7 +8,8 @@ from compass.collectors.import_graph import ImportGraphCollector
 from compass.domain.analysis_context import AnalysisContext
 from compass.domain.architecture_snapshot import ArchitectureSnapshot
 from compass.domain.file_score import FileScore
-from compass.storage.analysis_context_store import AnalysisContextStore  # type: ignore[import-not-found]  # storage module not yet merged
+
+from compass.storage.analysis_context_store import write_analysis_context
 
 
 class CollectorOrchestrator:
@@ -53,6 +54,6 @@ class CollectorOrchestrator:
 			docs=docs,
 		)
 
-		await AnalysisContextStore().write(target_path, context)
+		write_analysis_context(target_path, context)
 
 		return context

--- a/compass/config.py
+++ b/compass/config.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+PROVIDER_TIMEOUT: int = 120
+VALIDATION_RETRY_DELAY: int = 2
+
 
 @dataclass(frozen=True)
 class CompassConfig:

--- a/compass/providers/base.py
+++ b/compass/providers/base.py
@@ -7,25 +7,24 @@ from compass.errors import ConfigError
 
 
 class BaseProvider(ABC):
-	@abstractmethod
-	async def call(self, prompt: str) -> str:
-		...
+    @abstractmethod
+    async def call(self, prompt: str) -> str: ...
 
 
 def get_provider(config: CompassConfig) -> BaseProvider:
-	from compass.providers.claude import ClaudeProvider
-	from compass.providers.codex import CodexProvider
+    from compass.providers.claude import ClaudeProvider
+    from compass.providers.codex import CodexProvider
 
-	registry: dict[str, type[BaseProvider]] = {
-		'claude': ClaudeProvider,
-		'codex': CodexProvider,
-	}
+    registry: dict[str, type[BaseProvider]] = {
+        "claude": ClaudeProvider,
+        "codex": CodexProvider,
+    }
 
-	if not config.provider or config.provider not in registry:
-		raise ConfigError(
-			'provider',
-			config.provider,
-			f"one of: {', '.join(registry)}",
-		)
+    if not config.provider or config.provider not in registry:
+        raise ConfigError(
+            "provider",
+            config.provider,
+            f'one of: {", ".join(registry)}',
+        )
 
-	return registry[config.provider]()
+    return registry[config.provider]()

--- a/compass/providers/base.py
+++ b/compass/providers/base.py
@@ -7,24 +7,24 @@ from compass.errors import ConfigError
 
 
 class BaseProvider(ABC):
-    @abstractmethod
-    async def call(self, prompt: str) -> str: ...
+	@abstractmethod
+	async def call(self, prompt: str) -> str: ...
 
 
 def get_provider(config: CompassConfig) -> BaseProvider:
-    from compass.providers.claude import ClaudeProvider
-    from compass.providers.codex import CodexProvider
+	from compass.providers.claude import ClaudeProvider
+	from compass.providers.codex import CodexProvider
 
-    registry: dict[str, type[BaseProvider]] = {
-        "claude": ClaudeProvider,
-        "codex": CodexProvider,
-    }
+	registry: dict[str, type[BaseProvider]] = {
+		'claude': ClaudeProvider,
+		'codex': CodexProvider,
+	}
 
-    if not config.provider or config.provider not in registry:
-        raise ConfigError(
-            "provider",
-            config.provider,
-            f'one of: {", ".join(registry)}',
-        )
+	if not config.provider or config.provider not in registry:
+		raise ConfigError(
+			'provider',
+			config.provider,
+			f'one of: {", ".join(registry)}',
+		)
 
-    return registry[config.provider]()
+	return registry[config.provider]()

--- a/compass/providers/base.py
+++ b/compass/providers/base.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from compass.config import CompassConfig
+from compass.errors import ConfigError
+
+
+class BaseProvider(ABC):
+	@abstractmethod
+	async def call(self, prompt: str) -> str:
+		...
+
+
+def get_provider(config: CompassConfig) -> BaseProvider:
+	from compass.providers.claude import ClaudeProvider
+	from compass.providers.codex import CodexProvider
+
+	registry: dict[str, type[BaseProvider]] = {
+		'claude': ClaudeProvider,
+		'codex': CodexProvider,
+	}
+
+	if not config.provider or config.provider not in registry:
+		raise ConfigError(
+			'provider',
+			config.provider,
+			f"one of: {', '.join(registry)}",
+		)
+
+	return registry[config.provider]()

--- a/compass/providers/claude.py
+++ b/compass/providers/claude.py
@@ -11,12 +11,16 @@ class ClaudeProvider(BaseProvider):
 		proc = await asyncio.create_subprocess_exec(
 			'claude',
 			'-p',
-			prompt,
+			'-',
+			stdin=asyncio.subprocess.PIPE,
 			stdout=asyncio.subprocess.PIPE,
 			stderr=asyncio.subprocess.PIPE,
 		)
 		try:
-			stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=PROVIDER_TIMEOUT)
+			stdout, stderr = await asyncio.wait_for(
+				proc.communicate(input=prompt.encode()),
+				timeout=PROVIDER_TIMEOUT,
+			)
 		except asyncio.TimeoutError:
 			proc.kill()
 			await proc.wait()

--- a/compass/providers/claude.py
+++ b/compass/providers/claude.py
@@ -1,8 +1,26 @@
 from __future__ import annotations
 
+import asyncio
+
+from compass.config import PROVIDER_TIMEOUT
 from compass.providers.base import BaseProvider
 
 
 class ClaudeProvider(BaseProvider):
 	async def call(self, prompt: str) -> str:
-		raise NotImplementedError
+		proc = await asyncio.create_subprocess_exec(
+			'claude',
+			'-p',
+			prompt,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		try:
+			stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=PROVIDER_TIMEOUT)
+		except asyncio.TimeoutError:
+			proc.kill()
+			await proc.wait()
+			raise RuntimeError(f'claude CLI timed out after {PROVIDER_TIMEOUT}s')
+		if proc.returncode != 0:
+			raise RuntimeError(stderr.decode().strip() or 'claude CLI exited with non-zero status')
+		return stdout.decode().strip()

--- a/compass/providers/claude.py
+++ b/compass/providers/claude.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from compass.providers.base import BaseProvider
+
+
+class ClaudeProvider(BaseProvider):
+	async def call(self, prompt: str) -> str:
+		raise NotImplementedError

--- a/compass/providers/codex.py
+++ b/compass/providers/codex.py
@@ -11,7 +11,6 @@ class CodexProvider(BaseProvider):
 		proc = await asyncio.create_subprocess_exec(
 			'codex',
 			'exec',
-			'-p',
 			'-',
 			stdin=asyncio.subprocess.PIPE,
 			stdout=asyncio.subprocess.PIPE,

--- a/compass/providers/codex.py
+++ b/compass/providers/codex.py
@@ -7,18 +7,25 @@ from compass.providers.base import BaseProvider
 
 
 class CodexProvider(BaseProvider):
-	async def call(self, prompt: str) -> str:
-		proc = await asyncio.create_subprocess_exec(
-			'codex', 'exec', '-p', prompt,
-			stdout=asyncio.subprocess.PIPE,
-			stderr=asyncio.subprocess.PIPE,
-		)
-		try:
-			stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=PROVIDER_TIMEOUT)
-		except asyncio.TimeoutError:
-			proc.kill()
-			await proc.wait()
-			raise RuntimeError(f'codex CLI timed out after {PROVIDER_TIMEOUT}s')
-		if proc.returncode != 0:
-			raise RuntimeError(stderr.decode().strip() or 'codex CLI exited with non-zero status')
-		return stdout.decode().strip()
+    async def call(self, prompt: str) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            "codex",
+            "exec",
+            "-p",
+            prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=PROVIDER_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError(f"codex CLI timed out after {PROVIDER_TIMEOUT}s")
+        if proc.returncode != 0:
+            raise RuntimeError(
+                stderr.decode().strip() or "codex CLI exited with non-zero status"
+            )
+        return stdout.decode().strip()

--- a/compass/providers/codex.py
+++ b/compass/providers/codex.py
@@ -7,25 +7,25 @@ from compass.providers.base import BaseProvider
 
 
 class CodexProvider(BaseProvider):
-    async def call(self, prompt: str) -> str:
-        proc = await asyncio.create_subprocess_exec(
-            "codex",
-            "exec",
-            "-p",
-            prompt,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=PROVIDER_TIMEOUT
-            )
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"codex CLI timed out after {PROVIDER_TIMEOUT}s")
-        if proc.returncode != 0:
-            raise RuntimeError(
-                stderr.decode().strip() or "codex CLI exited with non-zero status"
-            )
-        return stdout.decode().strip()
+	async def call(self, prompt: str) -> str:
+		proc = await asyncio.create_subprocess_exec(
+			'codex',
+			'exec',
+			'-p',
+			'-',
+			stdin=asyncio.subprocess.PIPE,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		try:
+			stdout, stderr = await asyncio.wait_for(
+				proc.communicate(input=prompt.encode()),
+				timeout=PROVIDER_TIMEOUT,
+			)
+		except asyncio.TimeoutError:
+			proc.kill()
+			await proc.wait()
+			raise RuntimeError(f'codex CLI timed out after {PROVIDER_TIMEOUT}s')
+		if proc.returncode != 0:
+			raise RuntimeError(stderr.decode().strip() or 'codex CLI exited with non-zero status')
+		return stdout.decode().strip()

--- a/compass/providers/codex.py
+++ b/compass/providers/codex.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from compass.providers.base import BaseProvider
+
+
+class CodexProvider(BaseProvider):
+	async def call(self, prompt: str) -> str:
+		raise NotImplementedError

--- a/compass/providers/codex.py
+++ b/compass/providers/codex.py
@@ -1,8 +1,24 @@
 from __future__ import annotations
 
+import asyncio
+
+from compass.config import PROVIDER_TIMEOUT
 from compass.providers.base import BaseProvider
 
 
 class CodexProvider(BaseProvider):
 	async def call(self, prompt: str) -> str:
-		raise NotImplementedError
+		proc = await asyncio.create_subprocess_exec(
+			'codex', 'exec', '-p', prompt,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		try:
+			stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=PROVIDER_TIMEOUT)
+		except asyncio.TimeoutError:
+			proc.kill()
+			await proc.wait()
+			raise RuntimeError(f'codex CLI timed out after {PROVIDER_TIMEOUT}s')
+		if proc.returncode != 0:
+			raise RuntimeError(stderr.decode().strip() or 'codex CLI exited with non-zero status')
+		return stdout.decode().strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   # Installed with Compass per FINAL.md prerequisites.
   "grep_ast",
   "mcp",
+  "networkx>=3.0",
   "pydantic>=2,<3",
   # Needed for .compass/config.yaml and ~/.compass/config.yaml parsing.
   "PyYAML>=6.0",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,4 @@
-import sys
-from unittest.mock import MagicMock
-
 # Must be set before any test module is imported, because orchestrator.py
 # imports compass.storage at module level (storage module not yet merged).
-sys.modules.setdefault('compass.storage', MagicMock())
-sys.modules.setdefault('compass.storage.analysis_context_store', MagicMock())
+# sys.modules.setdefault('compass.storage', MagicMock())
+# sys.modules.setdefault('compass.storage.analysis_context_store', MagicMock())

--- a/tests/unit/test_adapter_base.py
+++ b/tests/unit/test_adapter_base.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from compass.adapters.base import AdapterBase
+from compass.config import CompassConfig
+from compass.errors import ProviderError, SchemaValidationError
+from compass.paths import compass_paths
+
+
+class _TestAdapter(AdapterBase):
+	name = 'test'
+
+
+def _config(provider: str = 'claude') -> CompassConfig:
+	return CompassConfig(target_path='/tmp/repo', adapters=['test'], provider=provider)
+
+
+@pytest.fixture
+def adapter(tmp_path):
+	config = _config()
+	with patch('compass.adapters.base.get_provider') as mock_get:
+		mock_provider = MagicMock()
+		mock_provider.call = AsyncMock(return_value='provider response')
+		mock_get.return_value = mock_provider
+		inst = _TestAdapter(config, compass_paths(tmp_path))
+		inst._provider = mock_provider
+		return inst
+
+
+# --- run_file_selector ---
+
+
+def test_run_file_selector_returns_empty_list(adapter):
+	result = adapter.run_file_selector({'type': 'high_centrality'})
+	assert result == []
+
+
+# --- call_provider ---
+
+
+async def test_call_provider_returns_response(adapter):
+	adapter._provider.call = AsyncMock(return_value='LLM output')
+	result = await adapter.call_provider('my prompt')
+	assert result == 'LLM output'
+
+
+async def test_call_provider_wraps_runtime_error_as_provider_error(adapter):
+	adapter._provider.call = AsyncMock(side_effect=RuntimeError('timed out'))
+	with pytest.raises(ProviderError):
+		await adapter.call_provider('my prompt')
+
+
+# --- validate_output ---
+
+
+async def test_validate_output_returns_result_when_valid(adapter):
+	validator = MagicMock(return_value='parsed')
+	adapter.call_provider = AsyncMock(return_value='raw response')
+	result = await adapter.validate_output('raw response', validator, 'original prompt')
+	assert result == 'parsed'
+	validator.assert_called_once_with('raw response')
+
+
+async def test_validate_output_retries_once_on_validation_failure(adapter):
+	call_count = 0
+
+	def validator(raw: str) -> str:
+		nonlocal call_count
+		call_count += 1
+		if call_count == 1:
+			raise ValueError('missing required section')
+		return 'parsed on retry'
+
+	adapter.call_provider = AsyncMock(return_value='retry response')
+
+	with patch('asyncio.sleep', new_callable=AsyncMock):
+		result = await adapter.validate_output('bad response', validator, 'original prompt')
+
+	assert result == 'parsed on retry'
+	assert call_count == 2
+	adapter.call_provider.assert_called_once()
+	call_args = adapter.call_provider.call_args[0][0]
+	assert 'original prompt' in call_args
+	assert 'missing required section' in call_args
+
+
+async def test_validate_output_raises_schema_error_after_second_failure(adapter):
+	def validator(raw: str) -> str:
+		raise ValueError('still invalid')
+
+	adapter.call_provider = AsyncMock(return_value='retry response')
+
+	with patch('asyncio.sleep', new_callable=AsyncMock):
+		with pytest.raises(SchemaValidationError):
+			await adapter.validate_output('bad response', validator, 'original prompt')
+
+
+async def test_validate_output_does_not_call_provider_when_first_attempt_succeeds(adapter):
+	validator = MagicMock(return_value='parsed')
+	adapter.call_provider = AsyncMock()
+
+	await adapter.validate_output('good response', validator, 'original prompt')
+
+	adapter.call_provider.assert_not_called()
+
+
+# --- run_grep_ast ---
+
+
+async def test_run_grep_ast_returns_stdout_from_subprocess(adapter, tmp_path):
+	fake_file = tmp_path / 'module.py'
+	fake_file.write_text('def foo(): pass')
+
+	mock_proc = MagicMock()
+	mock_proc.returncode = 0
+	mock_proc.communicate = AsyncMock(return_value=(b'def foo(): pass\n', b''))
+
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = mock_proc
+		result = await adapter.run_grep_ast([str(fake_file)])
+
+	assert 'def foo' in result
+
+
+async def test_run_grep_ast_returns_empty_string_for_no_files(adapter):
+	result = await adapter.run_grep_ast([])
+	assert result == ''

--- a/tests/unit/test_adapter_base.py
+++ b/tests/unit/test_adapter_base.py
@@ -12,6 +12,9 @@ from compass.paths import compass_paths
 class _TestAdapter(AdapterBase):
 	name = 'test'
 
+	async def run(self) -> None:
+		pass
+
 
 def _config(provider: str = 'claude') -> CompassConfig:
 	return CompassConfig(target_path='/tmp/repo', adapters=['test'], provider=provider)

--- a/tests/unit/test_adapter_orchestrator.py
+++ b/tests/unit/test_adapter_orchestrator.py
@@ -1,6 +1,4 @@
-<<<<<<< HEAD
 from __future__ import annotations
-
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -42,7 +40,6 @@ async def test_orchestrator_skips_unknown_adapter():
 	with patch('compass.adapters.orchestrator.ADAPTER_REGISTRY', registry):
 		orchestrator = Orchestrator(config)
 		await orchestrator.run()
-	# No exception raised — unknown adapter is skipped
 
 
 async def test_orchestrator_continues_after_adapter_failure():
@@ -70,79 +67,3 @@ async def test_orchestrator_runs_only_requested_adapters():
 
 	rules_cls.return_value.run.assert_called_once()
 	summary_cls.return_value.run.assert_not_called()
-=======
-from unittest.mock import AsyncMock, patch
-
-import pytest
-
-from compass.collectors.git_log import FileGitData, GitLogResult
-from compass.collectors.import_graph import ImportGraphResult
-from compass.collectors.orchestrator import CollectorOrchestrator
-from compass.domain.analysis_context import AnalysisContext
-from compass.domain.cluster import Cluster
-from compass.domain.git_patterns_snapshot import GitPatternsSnapshot
-from compass.errors import CollectorError
-
-
-@pytest.fixture
-def fake_git_result():
-	return GitLogResult(
-		file_data={'main.py': FileGitData(churn=0.8, age=10, coupling_pairs=['utils.py'])},
-		coupling_pairs=[],
-		git_patterns=GitPatternsSnapshot(
-			hotspots=['main.py'],
-			stable_files=[],
-			coupling_clusters=[],
-		),
-	)
-
-
-@pytest.fixture
-def fake_import_graph_result():
-	return ImportGraphResult(
-		centrality={'main.py': 0.5},
-		cluster_id={'main.py': 0},
-		clusters=[Cluster(id=0, files=('main.py',))],
-	)
-
-
-async def test_orchestrator_happy_path(tmp_path, fake_git_result, fake_import_graph_result):
-	with (
-		patch('compass.collectors.orchestrator.GitLogCollector') as MockGit,
-		patch('compass.collectors.orchestrator.AstGrepCollector') as MockAst,
-		patch('compass.collectors.orchestrator.DocsReaderCollector') as MockDocs,
-		patch('compass.collectors.orchestrator.ImportGraphCollector') as MockImport,
-		patch('compass.collectors.orchestrator.AnalysisContextStore') as MockStore,
-	):
-		MockGit.return_value.collect = AsyncMock(return_value=fake_git_result)
-		MockAst.return_value.collect = AsyncMock(
-			return_value={'error_handling': ['except ValueError']}
-		)
-		MockDocs.return_value.collect = AsyncMock(return_value={'README.md': 'hello'})
-		MockImport.return_value.collect = AsyncMock(return_value=fake_import_graph_result)
-		MockStore.return_value.write = AsyncMock()
-
-		orchestrator = CollectorOrchestrator()
-		result = await orchestrator.run(tmp_path)
-
-	assert isinstance(result, AnalysisContext)
-
-
-async def test_orchestrator_aborts_on_collector_failure(tmp_path, fake_import_graph_result):
-	with (
-		patch('compass.collectors.orchestrator.GitLogCollector') as MockGit,
-		patch('compass.collectors.orchestrator.AstGrepCollector') as MockAst,
-		patch('compass.collectors.orchestrator.DocsReaderCollector') as MockDocs,
-		patch('compass.collectors.orchestrator.ImportGraphCollector') as MockImport,
-	):
-		MockGit.return_value.collect = AsyncMock(
-			side_effect=CollectorError('GitLogCollector', 'git failed')
-		)
-		MockAst.return_value.collect = AsyncMock(return_value={'error_handling': []})
-		MockDocs.return_value.collect = AsyncMock(return_value={})
-		MockImport.return_value.collect = AsyncMock(return_value=fake_import_graph_result)
-
-		orchestrator = CollectorOrchestrator()
-		with pytest.raises(CollectorError):
-			await orchestrator.run(tmp_path)
->>>>>>> origin/dev

--- a/tests/unit/test_file_selector.py
+++ b/tests/unit/test_file_selector.py
@@ -146,7 +146,7 @@ def _build_context(file_scores: list[FileScore], hotspots: list[str]) -> Analysi
 		architecture=ArchitectureSnapshot(
 			file_scores=file_scores,
 			coupling_pairs=coupling_pairs,
-			clusters=[Cluster(id=0, files=[file_score.path for file_score in file_scores])],
+			clusters=[Cluster(id=0, files=tuple(file_score.path for file_score in file_scores))],
 		),
 		patterns={},
 		git_patterns=GitPatternsSnapshot(
@@ -165,7 +165,7 @@ def _build_file_score(path: str, centrality: float, churn: float, coupling_count
 		age=1,
 		centrality=centrality,
 		cluster_id=0,
-		coupling_pairs=[f'dependency-{index}' for index in range(coupling_count)],
+		coupling_pairs=tuple(f'dependency-{index}' for index in range(coupling_count)),
 	)
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from compass.adapters.orchestrator import Orchestrator
+from compass.config import CompassConfig
+from compass.errors import AdapterError
+
+
+def _config(adapters: list[str], provider: str = 'claude') -> CompassConfig:
+	return CompassConfig(target_path='/tmp/repo', adapters=adapters, provider=provider)
+
+
+def _mock_adapter_cls(name: str, *, fail: bool = False) -> type:
+	instance = MagicMock()
+	if fail:
+		instance.run = AsyncMock(side_effect=AdapterError(name, 'something went wrong'))
+	else:
+		instance.run = AsyncMock()
+	cls = MagicMock(return_value=instance)
+	return cls
+
+
+async def test_orchestrator_runs_registered_adapter():
+	mock_cls = _mock_adapter_cls('rules')
+	registry = {'rules': mock_cls}
+	config = _config(['rules'])
+
+	with patch('compass.adapters.orchestrator.ADAPTER_REGISTRY', registry):
+		orchestrator = Orchestrator(config)
+		await orchestrator.run()
+
+	mock_cls.return_value.run.assert_called_once()
+
+
+async def test_orchestrator_skips_unknown_adapter():
+	config = _config(['unknown_adapter'])
+	registry: dict = {}
+
+	with patch('compass.adapters.orchestrator.ADAPTER_REGISTRY', registry):
+		orchestrator = Orchestrator(config)
+		await orchestrator.run()
+	# No exception raised — unknown adapter is skipped
+
+
+async def test_orchestrator_continues_after_adapter_failure():
+	failing_cls = _mock_adapter_cls('rules', fail=True)
+	passing_cls = _mock_adapter_cls('summary')
+	registry = {'rules': failing_cls, 'summary': passing_cls}
+	config = _config(['rules', 'summary'])
+
+	with patch('compass.adapters.orchestrator.ADAPTER_REGISTRY', registry):
+		orchestrator = Orchestrator(config)
+		await orchestrator.run()
+
+	passing_cls.return_value.run.assert_called_once()
+
+
+async def test_orchestrator_runs_only_requested_adapters():
+	rules_cls = _mock_adapter_cls('rules')
+	summary_cls = _mock_adapter_cls('summary')
+	registry = {'rules': rules_cls, 'summary': summary_cls}
+	config = _config(['rules'])
+
+	with patch('compass.adapters.orchestrator.ADAPTER_REGISTRY', registry):
+		orchestrator = Orchestrator(config)
+		await orchestrator.run()
+
+	rules_cls.return_value.run.assert_called_once()
+	summary_cls.return_value.run.assert_not_called()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -39,7 +39,7 @@ async def test_orchestrator_happy_path(tmp_path, fake_git_result, fake_import_gr
 		patch('compass.collectors.orchestrator.AstGrepCollector') as MockAst,
 		patch('compass.collectors.orchestrator.DocsReaderCollector') as MockDocs,
 		patch('compass.collectors.orchestrator.ImportGraphCollector') as MockImport,
-		patch('compass.collectors.orchestrator.AnalysisContextStore') as MockStore,
+		patch('compass.collectors.orchestrator.write_analysis_context'),
 	):
 		MockGit.return_value.collect = AsyncMock(return_value=fake_git_result)
 		MockAst.return_value.collect = AsyncMock(
@@ -47,7 +47,9 @@ async def test_orchestrator_happy_path(tmp_path, fake_git_result, fake_import_gr
 		)
 		MockDocs.return_value.collect = AsyncMock(return_value={'README.md': 'hello'})
 		MockImport.return_value.collect = AsyncMock(return_value=fake_import_graph_result)
-		MockStore.return_value.write = AsyncMock()
+
+		# orchestrator.py now calls write_analysis_context() as a standard function,
+		# so we don't need to mock a nested .write() method anymore.
 
 		orchestrator = CollectorOrchestrator()
 		result = await orchestrator.run(tmp_path)

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from compass.config import CompassConfig
+from compass.config import CompassConfig, PROVIDER_TIMEOUT
 from compass.errors import ConfigError
 from compass.providers.base import get_provider
 from compass.providers.claude import ClaudeProvider
@@ -31,3 +34,51 @@ def test_get_provider_raises_config_error_on_none():
 def test_get_provider_raises_config_error_on_unknown():
 	with pytest.raises(ConfigError):
 		get_provider(_config('gpt4'))
+
+
+def _make_proc(returncode: int, stdout: bytes, stderr: bytes) -> MagicMock:
+	proc = MagicMock()
+	proc.returncode = returncode
+	proc.communicate = AsyncMock(return_value=(stdout, stderr))
+	proc.kill = MagicMock()
+	proc.wait = AsyncMock()
+	return proc
+
+
+async def test_claude_returns_stdout_on_success():
+	proc = _make_proc(0, b'  extracted rules  ', b'')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = ClaudeProvider()
+		result = await provider.call('my prompt')
+
+	assert result == 'extracted rules'
+	mock_exec.assert_called_once_with(
+		'claude',
+		'-p',
+		'my prompt',
+		stdout=asyncio.subprocess.PIPE,
+		stderr=asyncio.subprocess.PIPE,
+	)
+
+
+async def test_claude_raises_runtime_error_on_nonzero_exit():
+	proc = _make_proc(1, b'', b'rate limit hit')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = ClaudeProvider()
+		with pytest.raises(RuntimeError, match='rate limit hit'):
+			await provider.call('my prompt')
+
+
+async def test_claude_raises_runtime_error_on_timeout():
+	proc = MagicMock()
+	proc.kill = MagicMock()
+	proc.wait = AsyncMock()
+	proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = ClaudeProvider()
+		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
+			await provider.call('my prompt')
+	proc.kill.assert_called_once()

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -13,109 +13,112 @@ from compass.providers.codex import CodexProvider
 
 
 def _config(provider: str | None) -> CompassConfig:
-	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider=provider)
+    return CompassConfig(target_path="/tmp/repo", adapters=["rules"], provider=provider)
 
 
 def test_get_provider_returns_claude_provider():
-	provider = get_provider(_config('claude'))
-	assert isinstance(provider, ClaudeProvider)
+    provider = get_provider(_config("claude"))
+    assert isinstance(provider, ClaudeProvider)
 
 
 def test_get_provider_returns_codex_provider():
-	provider = get_provider(_config('codex'))
-	assert isinstance(provider, CodexProvider)
+    provider = get_provider(_config("codex"))
+    assert isinstance(provider, CodexProvider)
 
 
 def test_get_provider_raises_config_error_on_none():
-	with pytest.raises(ConfigError):
-		get_provider(_config(None))
+    with pytest.raises(ConfigError):
+        get_provider(_config(None))
 
 
 def test_get_provider_raises_config_error_on_unknown():
-	with pytest.raises(ConfigError):
-		get_provider(_config('gpt4'))
+    with pytest.raises(ConfigError):
+        get_provider(_config("gpt4"))
 
 
 def _make_proc(returncode: int, stdout: bytes, stderr: bytes) -> MagicMock:
-	proc = MagicMock()
-	proc.returncode = returncode
-	proc.communicate = AsyncMock(return_value=(stdout, stderr))
-	proc.kill = MagicMock()
-	proc.wait = AsyncMock()
-	return proc
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
 
 
 async def test_claude_returns_stdout_on_success():
-	proc = _make_proc(0, b'  extracted rules  ', b'')
-	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
-		mock_exec.return_value = proc
-		provider = ClaudeProvider()
-		result = await provider.call('my prompt')
+    proc = _make_proc(0, b"  extracted rules  ", b"")
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        provider = ClaudeProvider()
+        result = await provider.call("my prompt")
 
-	assert result == 'extracted rules'
-	mock_exec.assert_called_once_with(
-		'claude',
-		'-p',
-		'my prompt',
-		stdout=asyncio.subprocess.PIPE,
-		stderr=asyncio.subprocess.PIPE,
-	)
+    assert result == "extracted rules"
+    mock_exec.assert_called_once_with(
+        "claude",
+        "-p",
+        "my prompt",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
 
 
 async def test_claude_raises_runtime_error_on_nonzero_exit():
-	proc = _make_proc(1, b'', b'rate limit hit')
-	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
-		mock_exec.return_value = proc
-		provider = ClaudeProvider()
-		with pytest.raises(RuntimeError, match='rate limit hit'):
-			await provider.call('my prompt')
+    proc = _make_proc(1, b"", b"rate limit hit")
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        provider = ClaudeProvider()
+        with pytest.raises(RuntimeError, match="rate limit hit"):
+            await provider.call("my prompt")
 
 
 async def test_claude_raises_runtime_error_on_timeout():
-	proc = MagicMock()
-	proc.kill = MagicMock()
-	proc.wait = AsyncMock()
-	proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
-	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
-		mock_exec.return_value = proc
-		provider = ClaudeProvider()
-		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
-			await provider.call('my prompt')
-	proc.kill.assert_called_once()
+    proc = MagicMock()
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        provider = ClaudeProvider()
+        with pytest.raises(RuntimeError, match=f"{PROVIDER_TIMEOUT}s"):
+            await provider.call("my prompt")
+    proc.kill.assert_called_once()
 
 
 async def test_codex_returns_stdout_on_success():
-	proc = _make_proc(0, b'  codex output  ', b'')
-	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
-		mock_exec.return_value = proc
-		provider = CodexProvider()
-		result = await provider.call('my prompt')
+    proc = _make_proc(0, b"  codex output  ", b"")
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        provider = CodexProvider()
+        result = await provider.call("my prompt")
 
-	assert result == 'codex output'
-	mock_exec.assert_called_once_with(
-		'codex', 'exec', '-p', 'my prompt',
-		stdout=asyncio.subprocess.PIPE,
-		stderr=asyncio.subprocess.PIPE,
-	)
+    assert result == "codex output"
+    mock_exec.assert_called_once_with(
+        "codex",
+        "exec",
+        "-p",
+        "my prompt",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
 
 
 async def test_codex_raises_runtime_error_on_nonzero_exit():
-	proc = _make_proc(1, b'', b'quota exceeded')
-	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
-		mock_exec.return_value = proc
-		provider = CodexProvider()
-		with pytest.raises(RuntimeError, match='quota exceeded'):
-			await provider.call('my prompt')
+    proc = _make_proc(1, b"", b"quota exceeded")
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        provider = CodexProvider()
+        with pytest.raises(RuntimeError, match="quota exceeded"):
+            await provider.call("my prompt")
 
 
 async def test_codex_raises_runtime_error_on_timeout():
-	proc = MagicMock()
-	proc.kill = MagicMock()
-	proc.wait = AsyncMock()
-	proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
-	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
-		mock_exec.return_value = proc
-		provider = CodexProvider()
-		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
-			await provider.call('my prompt')
-	proc.kill.assert_called_once()
+    proc = MagicMock()
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        provider = CodexProvider()
+        with pytest.raises(RuntimeError, match=f"{PROVIDER_TIMEOUT}s"):
+            await provider.call("my prompt")
+    proc.kill.assert_called_once()

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from compass.config import CompassConfig
+from compass.errors import ConfigError
+from compass.providers.base import get_provider
+from compass.providers.claude import ClaudeProvider
+from compass.providers.codex import CodexProvider
+
+
+def _config(provider: str | None) -> CompassConfig:
+	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider=provider)
+
+
+def test_get_provider_returns_claude_provider():
+	provider = get_provider(_config('claude'))
+	assert isinstance(provider, ClaudeProvider)
+
+
+def test_get_provider_returns_codex_provider():
+	provider = get_provider(_config('codex'))
+	assert isinstance(provider, CodexProvider)
+
+
+def test_get_provider_raises_config_error_on_none():
+	with pytest.raises(ConfigError):
+		get_provider(_config(None))
+
+
+def test_get_provider_raises_config_error_on_unknown():
+	with pytest.raises(ConfigError):
+		get_provider(_config('gpt4'))

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -82,3 +82,40 @@ async def test_claude_raises_runtime_error_on_timeout():
 		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
 			await provider.call('my prompt')
 	proc.kill.assert_called_once()
+
+
+async def test_codex_returns_stdout_on_success():
+	proc = _make_proc(0, b'  codex output  ', b'')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = CodexProvider()
+		result = await provider.call('my prompt')
+
+	assert result == 'codex output'
+	mock_exec.assert_called_once_with(
+		'codex', 'exec', '-p', 'my prompt',
+		stdout=asyncio.subprocess.PIPE,
+		stderr=asyncio.subprocess.PIPE,
+	)
+
+
+async def test_codex_raises_runtime_error_on_nonzero_exit():
+	proc = _make_proc(1, b'', b'quota exceeded')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = CodexProvider()
+		with pytest.raises(RuntimeError, match='quota exceeded'):
+			await provider.call('my prompt')
+
+
+async def test_codex_raises_runtime_error_on_timeout():
+	proc = MagicMock()
+	proc.kill = MagicMock()
+	proc.wait = AsyncMock()
+	proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = CodexProvider()
+		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
+			await provider.call('my prompt')
+	proc.kill.assert_called_once()

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -13,112 +13,114 @@ from compass.providers.codex import CodexProvider
 
 
 def _config(provider: str | None) -> CompassConfig:
-    return CompassConfig(target_path="/tmp/repo", adapters=["rules"], provider=provider)
+	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider=provider)
 
 
 def test_get_provider_returns_claude_provider():
-    provider = get_provider(_config("claude"))
-    assert isinstance(provider, ClaudeProvider)
+	provider = get_provider(_config('claude'))
+	assert isinstance(provider, ClaudeProvider)
 
 
 def test_get_provider_returns_codex_provider():
-    provider = get_provider(_config("codex"))
-    assert isinstance(provider, CodexProvider)
+	provider = get_provider(_config('codex'))
+	assert isinstance(provider, CodexProvider)
 
 
 def test_get_provider_raises_config_error_on_none():
-    with pytest.raises(ConfigError):
-        get_provider(_config(None))
+	with pytest.raises(ConfigError):
+		get_provider(_config(None))
 
 
 def test_get_provider_raises_config_error_on_unknown():
-    with pytest.raises(ConfigError):
-        get_provider(_config("gpt4"))
+	with pytest.raises(ConfigError):
+		get_provider(_config('gpt4'))
 
 
 def _make_proc(returncode: int, stdout: bytes, stderr: bytes) -> MagicMock:
-    proc = MagicMock()
-    proc.returncode = returncode
-    proc.communicate = AsyncMock(return_value=(stdout, stderr))
-    proc.kill = MagicMock()
-    proc.wait = AsyncMock()
-    return proc
+	proc = MagicMock()
+	proc.returncode = returncode
+	proc.communicate = AsyncMock(return_value=(stdout, stderr))
+	proc.kill = MagicMock()
+	proc.wait = AsyncMock()
+	return proc
 
 
 async def test_claude_returns_stdout_on_success():
-    proc = _make_proc(0, b"  extracted rules  ", b"")
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-        mock_exec.return_value = proc
-        provider = ClaudeProvider()
-        result = await provider.call("my prompt")
+	proc = _make_proc(0, b'  extracted rules  ', b'')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = ClaudeProvider()
+		result = await provider.call('my prompt')
 
-    assert result == "extracted rules"
-    mock_exec.assert_called_once_with(
-        "claude",
-        "-p",
-        "my prompt",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
+	assert result == 'extracted rules'
+	mock_exec.assert_called_once_with(
+		'claude',
+		'-p',
+		'-',
+		stdin=asyncio.subprocess.PIPE,
+		stdout=asyncio.subprocess.PIPE,
+		stderr=asyncio.subprocess.PIPE,
+	)
 
 
 async def test_claude_raises_runtime_error_on_nonzero_exit():
-    proc = _make_proc(1, b"", b"rate limit hit")
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-        mock_exec.return_value = proc
-        provider = ClaudeProvider()
-        with pytest.raises(RuntimeError, match="rate limit hit"):
-            await provider.call("my prompt")
+	proc = _make_proc(1, b'', b'rate limit hit')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = ClaudeProvider()
+		with pytest.raises(RuntimeError, match='rate limit hit'):
+			await provider.call('my prompt')
 
 
 async def test_claude_raises_runtime_error_on_timeout():
-    proc = MagicMock()
-    proc.kill = MagicMock()
-    proc.wait = AsyncMock()
-    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-        mock_exec.return_value = proc
-        provider = ClaudeProvider()
-        with pytest.raises(RuntimeError, match=f"{PROVIDER_TIMEOUT}s"):
-            await provider.call("my prompt")
-    proc.kill.assert_called_once()
+	proc = MagicMock()
+	proc.kill = MagicMock()
+	proc.wait = AsyncMock()
+	proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = ClaudeProvider()
+		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
+			await provider.call('my prompt')
+	proc.kill.assert_called_once()
 
 
 async def test_codex_returns_stdout_on_success():
-    proc = _make_proc(0, b"  codex output  ", b"")
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-        mock_exec.return_value = proc
-        provider = CodexProvider()
-        result = await provider.call("my prompt")
+	proc = _make_proc(0, b'  codex output  ', b'')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = CodexProvider()
+		result = await provider.call('my prompt')
 
-    assert result == "codex output"
-    mock_exec.assert_called_once_with(
-        "codex",
-        "exec",
-        "-p",
-        "my prompt",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
+	assert result == 'codex output'
+	mock_exec.assert_called_once_with(
+		'codex',
+		'exec',
+		'-p',
+		'-',
+		stdin=asyncio.subprocess.PIPE,
+		stdout=asyncio.subprocess.PIPE,
+		stderr=asyncio.subprocess.PIPE,
+	)
 
 
 async def test_codex_raises_runtime_error_on_nonzero_exit():
-    proc = _make_proc(1, b"", b"quota exceeded")
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-        mock_exec.return_value = proc
-        provider = CodexProvider()
-        with pytest.raises(RuntimeError, match="quota exceeded"):
-            await provider.call("my prompt")
+	proc = _make_proc(1, b'', b'quota exceeded')
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = CodexProvider()
+		with pytest.raises(RuntimeError, match='quota exceeded'):
+			await provider.call('my prompt')
 
 
 async def test_codex_raises_runtime_error_on_timeout():
-    proc = MagicMock()
-    proc.kill = MagicMock()
-    proc.wait = AsyncMock()
-    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-        mock_exec.return_value = proc
-        provider = CodexProvider()
-        with pytest.raises(RuntimeError, match=f"{PROVIDER_TIMEOUT}s"):
-            await provider.call("my prompt")
-    proc.kill.assert_called_once()
+	proc = MagicMock()
+	proc.kill = MagicMock()
+	proc.wait = AsyncMock()
+	proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+	with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+		mock_exec.return_value = proc
+		provider = CodexProvider()
+		with pytest.raises(RuntimeError, match=f'{PROVIDER_TIMEOUT}s'):
+			await provider.call('my prompt')
+	proc.kill.assert_called_once()

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -96,7 +96,6 @@ async def test_codex_returns_stdout_on_success():
 	mock_exec.assert_called_once_with(
 		'codex',
 		'exec',
-		'-p',
 		'-',
 		stdin=asyncio.subprocess.PIPE,
 		stdout=asyncio.subprocess.PIPE,

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -33,11 +33,11 @@ def _build_analysis_context() -> AnalysisContext:
 					age=14,
 					centrality=0.6,
 					cluster_id=1,
-					coupling_pairs=['src/utils.py'],
+					coupling_pairs=('src/utils.py',),
 				)
 			],
 			coupling_pairs=[CouplingPair(file_a='src/app.py', file_b='src/utils.py', degree=3)],
-			clusters=[Cluster(id=1, files=['src/app.py', 'src/utils.py'])],
+			clusters=[Cluster(id=1, files=('src/app.py', 'src/utils.py'))],
 		),
 		patterns={'naming': ['snake_case']},
 		git_patterns=GitPatternsSnapshot(

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -54,11 +54,11 @@ def _build_fake_analysis_context() -> FakeAnalysisContext:
 					age=14,
 					centrality=0.7,
 					cluster_id=1,
-					coupling_pairs=['src/utils.py'],
+					coupling_pairs=('src/utils.py',),
 				)
 			],
 			coupling_pairs=[CouplingPair(file_a='src/app.py', file_b='src/utils.py', degree=3)],
-			clusters=[Cluster(id=1, files=['src/app.py', 'src/utils.py'])],
+			clusters=[Cluster(id=1, files=('src/app.py', 'src/utils.py'))],
 		),
 		patterns={'naming': ['snake_case']},
 		git_patterns=GitPatternsSnapshot(


### PR DESCRIPTION
## Summary

- Adds `providers/` package: `BaseProvider` ABC, `get_provider()` factory, `ClaudeProvider` (`claude -p`), and `CodexProvider` (`codex exec -p`) — both using `asyncio.create_subprocess_exec` with timeout and error handling
- Adds `adapters/base.py`: shared runtime with `run_file_selector` (stub, pending #20), `run_grep_ast`, `call_provider`, `validate_output` (1 retry with appended error, then `SchemaValidationError`), and abstract `run()`
- Adds `adapters/orchestrator.py`: sequential adapter loop — continues on single adapter failure, logs per-adapter errors
- Adds `PROVIDER_TIMEOUT = 120` and `VALIDATION_RETRY_DELAY = 2` to `config.py`

## Notes

- `run_file_selector` is stubbed (`return []`) until issue #20 (FileSelector/collectors) is ready
- `ADAPTER_REGISTRY` in `orchestrator.py` is empty — populated when #30 and #31 land
- `run_grep_ast` uses `grep-ast --no-color` — exact flags should be verified before #30

## Test plan

- [ ] `pytest tests/unit/` — 42 tests, all passing
- [ ] `ruff format` + `ruff check` clean
- [ ] Providers tested with mocked subprocesses (success, non-zero exit, timeout)
- [ ] AdapterBase tested: retry flow, error wrapping, file selector stub, grep_ast stub
- [ ] Orchestrator tested: runs only requested adapters, continues after failure, skips unknowns

Closes #29
Must be merged before #30 and #31 can start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)