### PR TITLE
feat(skeleton): add render_skeletons with grep_ast skeleton rendering

### DIFF
--- a/compass/errors.py
+++ b/compass/errors.py
@@ -28,6 +28,13 @@ class CollectorError(CompassError):
 		super().__init__(f"Collector '{collector}' failed: {reason}")
 
 
+class SkeletonError(CompassError):
+	"""Raised when skeleton rendering fails."""
+
+	def __init__(self, reason: str) -> None:
+		super().__init__(f'Skeleton render failed: {reason}')
+
+
 class AdapterError(CompassError):
 	"""Raised when Phase 2 adapter execution fails."""
 

--- a/compass/skeleton.py
+++ b/compass/skeleton.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from grep_ast.grep_ast import TreeContext
+from grep_ast.parsers import filename_to_lang
+
+from compass.errors import SkeletonError
+
+
+def render_skeletons(paths: list[str]) -> dict[str, str]:
+	result = {}
+	for path in paths:
+		if not filename_to_lang(path):
+			continue
+		try:
+			code = Path(path).read_text(encoding='utf-8')
+		except (OSError, UnicodeDecodeError) as e:
+			raise SkeletonError(str(e)) from e
+		tc = TreeContext(path, code, child_context=False)
+		tc.show_lines = {
+		    i for i, nodes in enumerate(tc.nodes)
+			if any(n.end_point[0] > i for n in nodes)
+		}
+		skeleton = tc.format()
+		if skeleton:
+			result[path] = skeleton
+	if not result:
+		raise SkeletonError('no supported files found')
+	return result

--- a/compass/skeleton.py
+++ b/compass/skeleton.py
@@ -17,8 +17,7 @@ def render_skeletons(paths: list[str]) -> dict[str, str]:
 			raise SkeletonError(str(e)) from e
 		tc = TreeContext(path, code, child_context=False)
 		tc.show_lines = {
-		    i for i, nodes in enumerate(tc.nodes)
-			if any(n.end_point[0] > i for n in nodes)
+			i for i, nodes in enumerate(tc.nodes) if any(n.end_point[0] > i for n in nodes)
 		}
 		skeleton = tc.format()
 		if skeleton:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ version = "0.1.0"
 description = "CLI pipeline for analyzing repositories and generating onboarding artifacts."
 readme = "FINAL.md"
 requires-python = ">=3.11"
-authors = [
-  { name = "Compass Team" },
-]
+authors = [{ name = "Compass Team" }]
 dependencies = [
   # Installed with Compass per FINAL.md prerequisites.
   "grep_ast",
@@ -45,18 +43,12 @@ include = ["compass*"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "--ignore=tests/integration --ignore=tests/fixtures"
-markers = [
-  "integration: marks tests as integration (deselect with '-m not integration')",
-]
+markers = ["integration: marks tests as integration (deselect with '-m not integration')"]
 
 [tool.ruff]
 line-length = 100
 target-version = "py311"
-extend-exclude = [
-    "PROMPTS/old_templates",
-    "prompts/old_templates",
-    "tests/fixtures/sample_repo_*",
-]
+extend-exclude = ["PROMPTS/old_templates", "prompts/old_templates", "tests/fixtures/sample_repo_*"]
 
 [tool.ruff.format]
 quote-style = "single"
@@ -67,8 +59,8 @@ docstring-code-format = true
 python_version = "3.11"
 packages = ["compass"]
 strict = false
-exclude = [
-    "^PROMPTS/old_templates",
-    "^prompts/old_templates",
-    "tests/fixtures/sample_repo_.*",
-]
+exclude = ["^PROMPTS/old_templates", "^prompts/old_templates", "tests/fixtures/sample_repo_.*"]
+
+[[tool.mypy.overrides]]
+module = "grep_ast.*"
+ignore_missing_imports = true

--- a/tests/unit/test_skeleton.py
+++ b/tests/unit/test_skeleton.py
@@ -1,0 +1,41 @@
+import pytest
+
+from compass.errors import SkeletonError
+from compass.skeleton import render_skeletons
+
+
+def test_render_skeletons_returns_structure_without_body(tmp_path):
+	code = 'class Foo:\n    def bar(self):\n        return 42\n'
+	f = tmp_path / 'foo.py'
+	f.write_text(code)
+	result = render_skeletons([str(tmp_path / 'foo.py')])
+
+	assert 'class Foo:' in result[str(f)]
+	assert 'return 42' not in result[str(f)]
+
+
+def test_render_skeletons_skips_unknown_language(tmp_path):
+	python_code = 'class Foo:\n    def bar(self):\n        return 42\n'
+	txt_code = 'This is a paragraph from a text file.'
+	python_file = tmp_path / 'foo.py'
+	text_file = tmp_path / 'bar.txt'
+	python_file.write_text(python_code)
+	text_file.write_text(txt_code)
+	result = render_skeletons([str(tmp_path / 'foo.py'), str(tmp_path / 'bar.txt')])
+
+	assert 'class Foo:' in result[str(python_file)]
+	assert 'return 42' not in result[str(python_file)]
+	assert str(text_file) not in result
+
+
+def test_render_skeletons_raises_when_all_files_unknown(tmp_path):
+	txt_code = 'This is a paragraph from a text file.'
+	text_file = tmp_path / 'bar.txt'
+	text_file.write_text(txt_code)
+	with pytest.raises(SkeletonError):
+		render_skeletons([str(tmp_path / 'bar.txt')])
+
+
+def test_render_skeletons_raises_on_missing_file():
+	with pytest.raises(SkeletonError):
+		render_skeletons(['/nonexistend/path/foo.py'])


### PR DESCRIPTION
## Summary
- Add `SkeletonError` to `errors.py`
- Add `compass/skeleton.py` with `render_skeletons(paths: list[str]) -> dict[str, str]` — wraps grep_ast TreeContext to render file skeletons (signatures and class shapes, no bodies) for Phase 2 adapter runtime
- 4 unit tests covering happy path, unknown language skipping, all-unknown error, and missing file error

## Test plan
- [ ] `pytest tests/unit/test_skeleton.py -v` — 4 passed
- [ ] `pytest tests/unit/ -v` — 33 passed, no regressions