### PR TITLE
Modify security scan command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run security scan
         run: |
-          bandit -r compass/
+          bandit -r compass/ -c pyproject.toml
   tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/FINAL.md
+++ b/FINAL.md
@@ -88,11 +88,12 @@ Override: `--lang python|typescript`
 - **Two LLM calls:** (1) Extraction — produces `rules.md` per domain batch with confidence markers and conflict flags; (2) Reconciliation — hallucination check + deduplication against golden files, outputs final validated `rules.md` → parsed deterministically to `rules.yaml`
 - Output schema: two-level cluster → rules (id, rule, why, example) — see examples/rules.yaml
 
-**SummaryAdapter → summary.md**
+**SummaryAdapter → summary.md + summary.json**
 - FileSelector: high-centrality + hotspots
 - Context: grep_ast skeletons only (structure is enough, no implementation bodies needed)
 - No repomix, no ast-grep patterns, no docs_reader
 - **Why no ast-grep patterns:** ast-grep answers "how is code written" (conventions, error handling style) — that is RulesAdapter's domain. SummaryAdapter answers "what does this do and how is it structured." grep_ast skeletons + git signals are sufficient; adding ast-grep patterns would pull the LLM toward convention output instead of architectural summary.
+- **Single LLM call produces both outputs:** `summary.md` (human-readable, five fixed sections) and `summary.json` (structured, for v2 FastAPI/UI layer). The LLM outputs both in one response — zero extra cost. Deterministic MD→JSON parsing is not used here (summary prose is not rigid enough for reliable parsing, unlike rules.md).
 
 ## AnalysisContext — v1 sections
 ```json
@@ -120,7 +121,8 @@ target-repo/
     └── output/
         ├── rules.md       ← RulesAdapter intermediate (human-readable)
         ├── rules.yaml     ← RulesAdapter final output (parsed from rules.md)
-        └── summary.md
+        ├── summary.md     ← SummaryAdapter human-readable output
+        └── summary.json   ← SummaryAdapter structured output (same LLM call)
 ```
 
 ## CLI


### PR DESCRIPTION
## Summary
- Pass `-c pyproject.toml` to bandit in CI so the config is actually picked up

## Why
Bandit does not auto-discover `pyproject.toml` — it requires an explicit `-c` flag. Without it, B404 (`import subprocess`) and B603 (`subprocess call`) were flagged in `repomix.py`, even though both are false positives: `paths` is internal FileSelector output (not user input), and `shell=False` is the safe default.

## Test plan
- [ ] `bandit -r compass/ -c pyproject.toml` — no issues identified
