### PR TITLE
fix(collectors): remove AnalysisContextStore write from CollectorOrchestrator

### DIFF
--- a/compass/collectors/orchestrator.py
+++ b/compass/collectors/orchestrator.py
@@ -8,7 +8,6 @@ from compass.collectors.import_graph import ImportGraphCollector
 from compass.domain.analysis_context import AnalysisContext
 from compass.domain.architecture_snapshot import ArchitectureSnapshot
 from compass.domain.file_score import FileScore
-from compass.storage.analysis_context_store import write_analysis_context
 
 
 class CollectorOrchestrator:
@@ -52,7 +51,5 @@ class CollectorOrchestrator:
 			git_patterns=git_result.git_patterns,
 			docs=docs,
 		)
-
-		write_analysis_context(target_path, context)
 
 		return context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,13 @@ requires-python = ">=3.11"
 authors = [{ name = "Compass Team" }]
 dependencies = [
   "dacite>=1.8",
-  "networkx>=3.0",
   # Installed with Compass per FINAL.md prerequisites.
   "grep_ast",
   "mcp",
-  "networkx>=3.0",
+  "networkx>=3,<4",
   "pydantic>=2,<3",
   # Needed for .compass/config.yaml and ~/.compass/config.yaml parsing.
   "PyYAML>=6.0",
-  "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,1 @@
-# Must be set before any test module is imported, because orchestrator.py
-# imports compass.storage at module level (storage module not yet merged).
-# sys.modules.setdefault('compass.storage', MagicMock())
-# sys.modules.setdefault('compass.storage.analysis_context_store', MagicMock())
+"""Unit-test-specific pytest configuration."""

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -11,8 +11,7 @@ from compass.domain.git_patterns_snapshot import GitPatternsSnapshot
 from compass.errors import CollectorError
 
 
-@pytest.fixture
-def fake_git_result():
+def build_git_result() -> GitLogResult:
 	return GitLogResult(
 		file_data={'main.py': FileGitData(churn=0.8, age=10, coupling_pairs=['utils.py'])},
 		coupling_pairs=[],
@@ -24,8 +23,7 @@ def fake_git_result():
 	)
 
 
-@pytest.fixture
-def fake_import_graph_result():
+def build_import_graph_result() -> ImportGraphResult:
 	return ImportGraphResult(
 		centrality={'main.py': 0.5},
 		cluster_id={'main.py': 0},
@@ -33,20 +31,22 @@ def fake_import_graph_result():
 	)
 
 
-async def test_orchestrator_happy_path(tmp_path, fake_git_result, fake_import_graph_result):
+async def test_orchestrator_happy_path(tmp_path):
+	git_result = build_git_result()
+	import_graph_result = build_import_graph_result()
+
 	with (
 		patch('compass.collectors.orchestrator.GitLogCollector') as MockGit,
 		patch('compass.collectors.orchestrator.AstGrepCollector') as MockAst,
 		patch('compass.collectors.orchestrator.DocsReaderCollector') as MockDocs,
 		patch('compass.collectors.orchestrator.ImportGraphCollector') as MockImport,
-		patch('compass.collectors.orchestrator.write_analysis_context'),
 	):
-		MockGit.return_value.collect = AsyncMock(return_value=fake_git_result)
+		MockGit.return_value.collect = AsyncMock(return_value=git_result)
 		MockAst.return_value.collect = AsyncMock(
 			return_value={'error_handling': ['except ValueError']}
 		)
 		MockDocs.return_value.collect = AsyncMock(return_value={'README.md': 'hello'})
-		MockImport.return_value.collect = AsyncMock(return_value=fake_import_graph_result)
+		MockImport.return_value.collect = AsyncMock(return_value=import_graph_result)
 
 		orchestrator = CollectorOrchestrator()
 		result = await orchestrator.run(tmp_path)
@@ -54,7 +54,9 @@ async def test_orchestrator_happy_path(tmp_path, fake_git_result, fake_import_gr
 	assert isinstance(result, AnalysisContext)
 
 
-async def test_orchestrator_aborts_on_collector_failure(tmp_path, fake_import_graph_result):
+async def test_orchestrator_aborts_on_collector_failure(tmp_path):
+	import_graph_result = build_import_graph_result()
+
 	with (
 		patch('compass.collectors.orchestrator.GitLogCollector') as MockGit,
 		patch('compass.collectors.orchestrator.AstGrepCollector') as MockAst,
@@ -66,7 +68,7 @@ async def test_orchestrator_aborts_on_collector_failure(tmp_path, fake_import_gr
 		)
 		MockAst.return_value.collect = AsyncMock(return_value={'error_handling': []})
 		MockDocs.return_value.collect = AsyncMock(return_value={})
-		MockImport.return_value.collect = AsyncMock(return_value=fake_import_graph_result)
+		MockImport.return_value.collect = AsyncMock(return_value=import_graph_result)
 
 		orchestrator = CollectorOrchestrator()
 		with pytest.raises(CollectorError):


### PR DESCRIPTION
## Summary

Remove storage persistence from `CollectorOrchestrator` and update orchestrator tests accordingly.

## Changes

- remove `AnalysisContextStore` usage from `compass/collectors/orchestrator.py`
- keep persistence ownership in `runner.py`
- update `tests/unit/test_orchestrator.py` to remove the old storage patch

## Verification

- `pytest tests/unit/test_orchestrator.py`
- `ruff check tests/unit/test_orchestrator.py`
- `ruff format --check tests/unit/test_orchestrator.py`
