### PR TITLE
fix(prerequisites): derive provider CLI checks from provider registry

### DIFF
--- a/compass/prerequisites.py
+++ b/compass/prerequisites.py
@@ -12,7 +12,7 @@ from typing import Final
 from urllib.request import urlopen
 
 from compass.errors import PrerequisiteError
-
+from compass.providers.base import PROVIDER_REGISTRY
 
 CODEBASE_MEMORY_MCP = 'codebase-memory-mcp'
 CODEBASE_MEMORY_MCP_RELEASES: Final[dict[tuple[str, str], str]] = {
@@ -91,7 +91,7 @@ def _require_binary(
 
 
 def _require_provider_cli() -> None:
-	if which('claude') is not None or which('codex') is not None:
+	if any(which(cls.cli_binary) is not None for cls in PROVIDER_REGISTRY.values()):
 		return
 	raise PrerequisiteError(
 		'provider CLI',

--- a/compass/providers/base.py
+++ b/compass/providers/base.py
@@ -1,30 +1,35 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 from compass.config import CompassConfig
 from compass.errors import ConfigError
 
 
 class BaseProvider(ABC):
+	cli_binary: ClassVar[str]
+
 	@abstractmethod
 	async def call(self, prompt: str) -> str: ...
 
 
 def get_provider(config: CompassConfig) -> BaseProvider:
-	from compass.providers.claude import ClaudeProvider
-	from compass.providers.codex import CodexProvider
 
-	registry: dict[str, type[BaseProvider]] = {
-		'claude': ClaudeProvider,
-		'codex': CodexProvider,
-	}
-
-	if not config.provider or config.provider not in registry:
+	if not config.provider or config.provider not in PROVIDER_REGISTRY:
 		raise ConfigError(
 			'provider',
 			config.provider,
-			f'one of: {", ".join(registry)}',
+			f'one of: {", ".join(PROVIDER_REGISTRY)}',
 		)
 
-	return registry[config.provider]()
+	return PROVIDER_REGISTRY[config.provider]()
+
+
+from compass.providers.claude import ClaudeProvider  # noqa: E402
+from compass.providers.codex import CodexProvider  # noqa: E402
+
+PROVIDER_REGISTRY = {
+	'claude': ClaudeProvider,
+	'codex': CodexProvider,
+}

--- a/compass/providers/claude.py
+++ b/compass/providers/claude.py
@@ -7,6 +7,8 @@ from compass.providers.base import BaseProvider
 
 
 class ClaudeProvider(BaseProvider):
+	cli_binary = 'claude'
+
 	async def call(self, prompt: str) -> str:
 		proc = await asyncio.create_subprocess_exec(
 			'claude',

--- a/compass/providers/codex.py
+++ b/compass/providers/codex.py
@@ -7,6 +7,8 @@ from compass.providers.base import BaseProvider
 
 
 class CodexProvider(BaseProvider):
+	cli_binary = 'codex'
+
 	async def call(self, prompt: str) -> str:
 		proc = await asyncio.create_subprocess_exec(
 			'codex',


### PR DESCRIPTION
## Summary
- `BaseProvider` gains a `cli_binary: ClassVar[str]` attribute; `ClaudeProvider` sets it to `'claude'`, `CodexProvider` to `'codex'`
- Provider registry extracted from inside `get_provider()` to module-level `PROVIDER_REGISTRY` in `providers/base.py`
- `_require_provider_cli()` now iterates `PROVIDER_REGISTRY` instead of hardcoding binary names — adding a new provider automatically includes its CLI in the prerequisite check

## Test plan
- [ ] All existing `test_prerequisites.py` tests pass
- [ ] `ruff check` and `ruff format --check` pass

---

Closes #60 