### PR TITLE
feat(rules): add parser and tests for reconciliation output

### DIFF
--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -16,7 +16,7 @@ class RulesAdapter(AdapterBase):
 	async def run(self) -> None:
 		pass
 
-	def _top_files(self, context) -> list[FileScore]:
+	def _top_files(self, context: AnalysisContext) -> list[FileScore]:
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
 			:10
 		]

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -85,7 +85,7 @@ class RulesAdapter(AdapterBase):
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
 
 	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
-		pattern = r"### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```"
+		pattern = r'### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```'
 		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
 		if not match:
 			raise ValueError(

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 
 from compass.adapters.base import AdapterBase
@@ -82,3 +83,12 @@ class RulesAdapter(AdapterBase):
 			'docs': context.docs,
 		}
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
+
+	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
+		pattern = r"### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```"
+		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
+		if not match:
+			raise ValueError(
+				"LLM Output missing strict section header '### FINAL YAML OUTPUT ###' or yaml fence."
+			)
+		return match.group(1).strip()

--- a/compass/prompts/templates/reconciliation.md
+++ b/compass/prompts/templates/reconciliation.md
@@ -258,3 +258,18 @@ a conservative, predictable gate — not a second extraction pass.
 - **Do not merge cross-domain duplicates.** Cross-reference them instead.
 - **Do not re-validate in `--after-all` mode.** The final merge pass operates
   only on already-validated per-batch output.
+
+---
+
+## Output Instructions
+
+Your final answer must end with the following block. No text after it.
+
+### FINAL YAML OUTPUT ###
+
+```yaml
+clusters:
+  your_cluster_name:
+    - "rule one"
+    - "rule two"
+```

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -9,50 +9,35 @@ from compass.paths import compass_paths
 
 
 def _config() -> CompassConfig:
-    return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
+	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
 
 
 @pytest.fixture
 def adapter(tmp_path):
-    config = _config()
-    with patch('compass.adapters.base.get_provider') as mock_get:
-        mock_provider = MagicMock()
-        mock_provider.call = AsyncMock(return_value='provider response')
-        mock_get.return_value = mock_provider
-        inst = RulesAdapter(config, compass_paths(tmp_path))
-        inst._provider = mock_provider
-        return inst
+	config = _config()
+	with patch('compass.adapters.base.get_provider') as mock_get:
+		mock_provider = MagicMock()
+		mock_provider.call = AsyncMock(return_value='provider response')
+		mock_get.return_value = mock_provider
+		inst = RulesAdapter(config, compass_paths(tmp_path))
+		inst._provider = mock_provider
+		return inst
 
 
 # --- parse_reconciliation_output ---
 
 
 def test_parse_reconciliation_output_success(adapter):
-    valid_llm_response = """
-    Some analysis text from the LLM.
+	raw = "Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - \"Always use explicit types\"\n```\n"
 
-    ### FINAL YAML OUTPUT ###
-    ```yaml
-    clusters:
-      typing:
-        - "Always use explicit types"
-    ```
-    """
+	result = adapter.parse_reconciliation_output(raw)
 
-    result = adapter.parse_reconciliation_output(valid_llm_response)
-
-    assert "clusters:" in result
-    assert "Always use explicit types" in result
+	assert "clusters:" in result
+	assert "Always use explicit types" in result
 
 
 def test_parse_reconciliation_output_raises_on_missing_header(adapter):
-    invalid_llm_response = """
-    Here is the yaml you asked for:
-    ```yaml
-    clusters:
-      typing: []
-    ```
-    """
+	raw = "Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n"
 
-    with pytest.raises(ValueError, match="missing strict section header"):
-        adapter.parse_reconciliation_output(invalid_llm_response)
+	with pytest.raises(ValueError, match="missing strict section header"):
+		adapter.parse_reconciliation_output(raw)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from compass.adapters.rules import RulesAdapter
+from compass.config import CompassConfig
+from compass.paths import compass_paths
+
+
+def _config() -> CompassConfig:
+    return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    config = _config()
+    with patch('compass.adapters.base.get_provider') as mock_get:
+        mock_provider = MagicMock()
+        mock_provider.call = AsyncMock(return_value='provider response')
+        mock_get.return_value = mock_provider
+        inst = RulesAdapter(config, compass_paths(tmp_path))
+        inst._provider = mock_provider
+        return inst
+
+
+# --- parse_reconciliation_output ---
+
+
+def test_parse_reconciliation_output_success(adapter):
+    valid_llm_response = """
+    Some analysis text from the LLM.
+
+    ### FINAL YAML OUTPUT ###
+    ```yaml
+    clusters:
+      typing:
+        - "Always use explicit types"
+    ```
+    """
+
+    result = adapter.parse_reconciliation_output(valid_llm_response)
+
+    assert "clusters:" in result
+    assert "Always use explicit types" in result
+
+
+def test_parse_reconciliation_output_raises_on_missing_header(adapter):
+    invalid_llm_response = """
+    Here is the yaml you asked for:
+    ```yaml
+    clusters:
+      typing: []
+    ```
+    """
+
+    with pytest.raises(ValueError, match="missing strict section header"):
+        adapter.parse_reconciliation_output(invalid_llm_response)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -28,16 +28,16 @@ def adapter(tmp_path):
 
 
 def test_parse_reconciliation_output_success(adapter):
-	raw = "Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - \"Always use explicit types\"\n```\n"
+	raw = 'Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - "Always use explicit types"\n```\n'
 
 	result = adapter.parse_reconciliation_output(raw)
 
-	assert "clusters:" in result
-	assert "Always use explicit types" in result
+	assert 'clusters:' in result
+	assert 'Always use explicit types' in result
 
 
 def test_parse_reconciliation_output_raises_on_missing_header(adapter):
-	raw = "Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n"
+	raw = 'Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n'
 
-	with pytest.raises(ValueError, match="missing strict section header"):
+	with pytest.raises(ValueError, match='missing strict section header'):
 		adapter.parse_reconciliation_output(raw)


### PR DESCRIPTION
Added ### FINAL YAML OUTPUT ### header to reconciliation.md so the LLM always outputs YAML in a predictable format
Implemented parse_reconciliation_output() in rules.py — uses regex to extract the YAML block by that header, raises ValueError if it's missing
Fixed missing type annotation on _top_files
Added happy path and sad path tests for the parser