### PR TITLE
[Phase 2] RulesAdapter

### DIFF
--- a/briefs/adapters_providers.md
+++ b/briefs/adapters_providers.md
@@ -1,6 +1,6 @@
 # Brief: Adapters & Providers
 
-Your job is to write **Phase 2** — the LLM synthesis layer. This is where `AnalysisContext` signals get turned into actual output files (`rules.yaml`, `summary.md`). One focused LLM call per adapter.
+Your job is to write **Phase 2** — the LLM synthesis layer. This is where `AnalysisContext` signals get turned into actual output files (`rules.yaml`, `summary.md`). One focused LLM call per adapter — except `RulesAdapter`, which makes **two** (see Part 3).
 
 **Prerequisite:** Domain models, foundation files, storage/CLI, and collectors should be substantially done before you start. You depend on `AnalysisContext` being populated and `FileSelector` being available.
 
@@ -64,16 +64,28 @@ The shared Phase 2 runtime. This is not an abstract base class with adapter-spec
 
 ## Part 3 — rules.py (`RulesAdapter`)
 
-Produces `rules.yaml`. Uses the most context of any adapter.
+Produces `rules.yaml`. Uses the most context of any adapter, and is the only adapter with **two LLM calls**.
 
+**Call 1 — Extraction**
+- Load `prompts/templates/extract_rules.md` via `load_template('extract_rules', lang)` (language-specific)
 - What context sections does `build_prompt()` assemble? (skeletons + repomix bodies + ast-grep patterns + git signals + docs + centrality)
 - How do you invoke `repomix --compress` on the selected files?
-- How do you load the correct prompt template? (language-specific — use `prompts/loader.py`)
-- The output must match the two-level cluster → rules schema. How do you validate it?
+- The extraction call produces an intermediate `rules.md` — write it to `.compass/output/rules.md` immediately after the call
 
-**Think about the prompt assembly order:**
+**Call 2 — Reconciliation**
+- Load `prompts/templates/reconciliation.md` via `load_template('reconciliation', lang)` (language-agnostic — no language sections, loader returns it as-is)
+- Build the reconciliation input: embed the extraction output (`rules.md`), plus `golden_files` (full source of high-centrality files from `AnalysisContext`) and `docs` (from `context.docs`)
+- The reconciliation call produces the **final** `rules.md` — overwrite `.compass/output/rules.md` with this
+
+**Parsing and validation**
+- After reconciliation, parse the final `rules.md` deterministically into a dict matching the `RulesOutput` schema
+- Pass it through `validate_output()` with a validator that calls `RulesOutput.model_validate(parsed_dict)` — raises on failure, triggering the retry loop
+- On success, serialise to YAML and write `rules.yaml`
+
+**Think about:**
+- What is a "golden file" in this context? (high-centrality files from `AnalysisContext.architecture.file_scores` — read their source from disk)
+- Where does the deterministic parser live? (in `rules.py` itself — no reuse case in v1)
 - What context does the LLM need first to understand the codebase?
-- How do you embed the output schema in the prompt so the LLM follows it?
 
 ---
 
@@ -104,10 +116,10 @@ Write the following unit test files in `tests/unit/`. Read TESTING.md → "Unit 
 
 | Test file | What it covers |
 |---|---|
-| `test_rules_adapter.py` | `build_prompt()` includes all expected context sections, validation flow, 1 retry on invalid output, hard error after second failure |
-| `test_summary_adapter.py` | `build_prompt()` includes only skeletons + git signals (assert no ast-grep patterns, no docs section), same validation flow |
+| `test_rules_adapter.py` | `build_prompt()` includes all expected context sections; reconciliation prompt includes extraction output + golden files + docs; validation flow; 1 retry on invalid output; hard error after second failure |
+| `test_summary_adapter.py` | `build_prompt()` includes grep_ast skeletons + git signals only — no ast-grep patterns, no docs section; same validation flow |
 
-Mock `call_provider()` in all tests — return controlled schema-valid (and intentionally invalid for retry tests) strings.
+Mock `call_provider()` in all tests — return controlled schema-valid (and intentionally invalid for retry tests) strings. For two-call tests (`RulesAdapter`), use `side_effect` to return different values per call.
 
 ---
 
@@ -116,6 +128,9 @@ Mock `call_provider()` in all tests — return controlled schema-valid (and inte
 - [ ] Both `claude.py` and `codex.py` wrap their respective CLI calls and return the LLM response as a string
 - [ ] `adapters/base.py` provides `run_file_selector()`, `run_grep_ast()`, `call_provider()`, `validate_output()`
 - [ ] `RulesAdapter.build_prompt()` includes all context sections listed in FINAL.md
+- [ ] `RulesAdapter` makes two LLM calls: extraction → `rules.md`, then reconciliation → final `rules.md` → `rules.yaml`
+- [ ] Reconciliation prompt embeds extraction output + golden file source + docs
+- [ ] Intermediate `rules.md` written after extraction; final `rules.md` overwritten after reconciliation
 - [ ] `SummaryAdapter.build_prompt()` includes only grep_ast skeletons + git signals
 - [ ] Invalid LLM output triggers exactly 1 retry, then raises `SchemaValidationError`
 - [ ] `ProviderError` is raised on non-zero CLI exit or timeout

--- a/compass/adapters/orchestrator.py
+++ b/compass/adapters/orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from compass.adapters.base import AdapterBase
+from compass.adapters.rules import RulesAdapter
 from compass.config import CompassConfig
 from compass.errors import AdapterError
 from compass.log import get_logger
@@ -9,7 +10,9 @@ from compass.paths import compass_paths
 log = get_logger(__name__)
 
 # Populated as concrete adapters are implemented (issues #30, #31).
-ADAPTER_REGISTRY: dict[str, type[AdapterBase]] = {}
+ADAPTER_REGISTRY: dict[str, type[AdapterBase]] = {
+	'rules': RulesAdapter,
+}
 
 
 class Orchestrator:

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 from compass.adapters.base import AdapterBase
 from compass.domain.analysis_context import AnalysisContext
 from compass.domain.file_score import FileScore
 from compass.language_detection import detect
 from compass.prompts.loader import load_template
+from compass.schemas.rules_schema import RulesOutput
 from compass.storage.analysis_context_store import read_analysis_context
 from compass.storage.output_writer import write_rules_md, write_rules_yaml
 
@@ -16,7 +21,8 @@ from compass.storage.output_writer import write_rules_md, write_rules_yaml
 class RulesAdapter(AdapterBase):
 	name = 'rules'
 
-	def _top_files(self, context) -> list[FileScore]:
+	def _top_files(self, context: AnalysisContext) -> list[FileScore]:
+
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
 			:10
 		]
@@ -83,6 +89,15 @@ class RulesAdapter(AdapterBase):
 		}
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
 
+	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
+		pattern = r'### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```'
+		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
+		if not match:
+			raise ValueError(
+				"LLM Output missing strict section header '### FINAL YAML OUTPUT ###' or yaml fence."
+			)
+		return match.group(1).strip()
+
 	async def run(self) -> None:
 		context = read_analysis_context(self._paths.target_path)
 		language = detect(self._paths.target_path, self._config.lang)
@@ -104,3 +119,11 @@ class RulesAdapter(AdapterBase):
 		)
 		final_rules_md = await self.call_provider(reconciliation_prompt)
 		write_rules_md(self._paths.target_path, final_rules_md)
+
+		yaml_str = self.parse_reconciliation_output(final_rules_md)
+
+		def validator(raw: str) -> Any:
+			return RulesOutput.model_validate(yaml.safe_load(raw))
+
+		validation_result = await self.validate_output(yaml_str, validator, reconciliation_prompt)
+		write_rules_yaml(self._paths.target_path, yaml.dump(validation_result.model_dump()))

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -16,7 +16,7 @@ class RulesAdapter(AdapterBase):
 	async def run(self) -> None:
 		pass
 
-	def _top_files(self, context) -> list[FileScore]:
+	def _top_files(self, context: AnalysisContext) -> list[FileScore]:
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
 			:10
 		]

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -90,7 +90,9 @@ class RulesAdapter(AdapterBase):
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
 
 	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
-		pattern = r'### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```'
+		# Anchored to the output section in compass/prompts/templates/reconciliation.md
+		pattern = r'### FINAL YAML OUTPUT ###.*?```yaml\s*(.*?)\s*```'
+
 		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
 		if not match:
 			raise ValueError(

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 
 from compass.adapters.base import AdapterBase
@@ -16,7 +17,7 @@ class RulesAdapter(AdapterBase):
 	async def run(self) -> None:
 		pass
 
-	def _top_files(self, context) -> list[FileScore]:
+	def _top_files(self, context: AnalysisContext) -> list[FileScore]:
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
 			:10
 		]
@@ -82,3 +83,12 @@ class RulesAdapter(AdapterBase):
 			'docs': context.docs,
 		}
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
+
+	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
+		pattern = r'### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```'
+		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
+		if not match:
+			raise ValueError(
+				"LLM Output missing strict section header '### FINAL YAML OUTPUT ###' or yaml fence."
+			)
+		return match.group(1).strip()

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -7,14 +7,14 @@ from pathlib import Path
 from compass.adapters.base import AdapterBase
 from compass.domain.analysis_context import AnalysisContext
 from compass.domain.file_score import FileScore
+from compass.language_detection import detect
 from compass.prompts.loader import load_template
+from compass.storage.analysis_context_store import read_analysis_context
+from compass.storage.output_writer import write_rules_md, write_rules_yaml
 
 
 class RulesAdapter(AdapterBase):
 	name = 'rules'
-
-	async def run(self) -> None:
-		pass
 
 	def _top_files(self, context) -> list[FileScore]:
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
@@ -82,3 +82,25 @@ class RulesAdapter(AdapterBase):
 			'docs': context.docs,
 		}
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
+
+	async def run(self) -> None:
+		context = read_analysis_context(self._paths.target_path)
+		language = detect(self._paths.target_path, self._config.lang)
+		files = self.run_file_selector({})
+
+		skeletons, repomix_bodies = await asyncio.gather(
+			self.run_grep_ast(files),
+			self._run_repomix(files),
+		)
+		repo_name = Path(self._paths.target_path).name
+		extraction_prompt = self.build_prompt(
+			context, skeletons, repomix_bodies, repo_name, language
+		)
+		rules_md = await self.call_provider(extraction_prompt)
+		write_rules_md(self._paths.target_path, rules_md)
+
+		reconciliation_prompt = self.build_reconciliation_prompt(
+			context, rules_md, repo_name, language
+		)
+		final_rules_md = await self.call_provider(reconciliation_prompt)
+		write_rules_md(self._paths.target_path, final_rules_md)

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from compass.adapters.base import AdapterBase
 from compass.domain.analysis_context import AnalysisContext
+from compass.domain.file_score import FileScore
 from compass.prompts.loader import load_template
 
 
@@ -14,6 +15,11 @@ class RulesAdapter(AdapterBase):
 
 	async def run(self) -> None:
 		pass
+
+	def _top_files(self, context) -> list[FileScore]:
+		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
+			:10
+		]
 
 	async def _run_repomix(self, files: list[str]) -> str:
 		if not files:
@@ -28,13 +34,11 @@ class RulesAdapter(AdapterBase):
 		stdout, _ = await proc.communicate()
 		return stdout.decode()
 
-	async def build_prompt(
+	def build_prompt(
 		self, context: AnalysisContext, skeletons: str, repomix_bodies: str, domain: str, lang: str
 	) -> str:
 		template = load_template('extract_rules', lang)
-		top_files = sorted(
-			context.architecture.file_scores, key=lambda s: s.centrality, reverse=True
-		)[:10]
+		top_files = self._top_files(context)
 		input_dict = {
 			'file_content': repomix_bodies,
 			'skeleton': skeletons,
@@ -61,4 +65,20 @@ class RulesAdapter(AdapterBase):
 			],
 		}
 
+		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
+
+	def build_reconciliation_prompt(
+		self, context: AnalysisContext, extracted_rules: str, domain: str, lang: str
+	) -> str:
+		template = load_template('reconciliation', lang)
+		top_files = self._top_files(context)
+		input_dict = {
+			'mode': 'per-batch',
+			'domain': domain,
+			'extracted_rules': extracted_rules,
+			'golden_files': [
+				{'path': score.path, 'content': Path(score.path).read_text()} for score in top_files
+			],
+			'docs': context.docs,
+		}
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+
+from compass.adapters.base import AdapterBase
+from compass.domain.analysis_context import AnalysisContext
+from compass.prompts.loader import load_template
+
+
+class RulesAdapter(AdapterBase):
+	name = 'rules'
+
+	async def run(self) -> None:
+		pass
+
+	async def _run_repomix(self, files: list[str]) -> str:
+		if not files:
+			return ''
+		proc = await asyncio.create_subprocess_exec(
+			'repomix',
+			'--compress',
+			*files,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		stdout, _ = await proc.communicate()
+		return stdout.decode()
+	
+	async def build_prompt(self, context: AnalysisContext, skeletons: str, repomix_bodies: str, lang: str) -> str:
+		template = load_template('extract_rules', lang)
+		input_dict = {
+			"domain": "",
+			"files": [{}],
+			"git_patterns": {
+				"hotspots": context.git_patterns.hotspots,
+				"stable_files": context.git_patterns.stable_files,
+				"coupling_clusters": context.git_patterns.coupling_clusters,
+			},
+			"docs": context.docs,
+			"golden_files": [{}]
+		}

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 
 from compass.adapters.base import AdapterBase
 from compass.domain.analysis_context import AnalysisContext
@@ -25,17 +27,38 @@ class RulesAdapter(AdapterBase):
 		)
 		stdout, _ = await proc.communicate()
 		return stdout.decode()
-	
-	async def build_prompt(self, context: AnalysisContext, skeletons: str, repomix_bodies: str, lang: str) -> str:
+
+	async def build_prompt(
+		self, context: AnalysisContext, skeletons: str, repomix_bodies: str, domain: str, lang: str
+	) -> str:
 		template = load_template('extract_rules', lang)
+		top_files = sorted(
+			context.architecture.file_scores, key=lambda s: s.centrality, reverse=True
+		)[:10]
 		input_dict = {
-			"domain": "",
-			"files": [{}],
-			"git_patterns": {
-				"hotspots": context.git_patterns.hotspots,
-				"stable_files": context.git_patterns.stable_files,
-				"coupling_clusters": context.git_patterns.coupling_clusters,
+			'file_content': repomix_bodies,
+			'skeleton': skeletons,
+			'ast_patterns': context.patterns,
+			'domain': domain,
+			'files': [
+				{
+					'path': score.path,
+					'churn': score.churn,
+					'age_days': score.age,
+					'centrality': score.centrality,
+					'coupling_pairs': list(score.coupling_pairs),
+				}
+				for score in context.architecture.file_scores
+			],
+			'git_patterns': {
+				'hotspots': context.git_patterns.hotspots,
+				'stable_files': context.git_patterns.stable_files,
+				'coupling_clusters': context.git_patterns.coupling_clusters,
 			},
-			"docs": context.docs,
-			"golden_files": [{}]
+			'docs': context.docs,
+			'golden_files': [
+				{'path': score.path, 'content': Path(score.path).read_text()} for score in top_files
+			],
 		}
+
+		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -85,7 +85,7 @@ class RulesAdapter(AdapterBase):
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
 
 	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
-		pattern = r"### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```"
+		pattern = r'### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```'
 		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
 		if not match:
 			raise ValueError(

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 
 from compass.adapters.base import AdapterBase
@@ -82,3 +83,12 @@ class RulesAdapter(AdapterBase):
 			'docs': context.docs,
 		}
 		return f'{template}\n\n## Input\n\n```json\n{json.dumps(input_dict, indent=2)}\n```'
+
+	def parse_reconciliation_output(self, raw_llm_output: str) -> str:
+		pattern = r"### FINAL YAML OUTPUT ###\s*```(?:yaml)?\n(.*?)```"
+		match = re.search(pattern, raw_llm_output, re.DOTALL | re.IGNORECASE)
+		if not match:
+			raise ValueError(
+				"LLM Output missing strict section header '### FINAL YAML OUTPUT ###' or yaml fence."
+			)
+		return match.group(1).strip()

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -122,10 +122,11 @@ class RulesAdapter(AdapterBase):
 		final_rules_md = await self.call_provider(reconciliation_prompt)
 		write_rules_md(self._paths.target_path, final_rules_md)
 
-		yaml_str = self.parse_reconciliation_output(final_rules_md)
-
 		def validator(raw: str) -> Any:
-			return RulesOutput.model_validate(yaml.safe_load(raw))
+			yaml_str = self.parse_reconciliation_output(raw)
+			return RulesOutput.model_validate(yaml.safe_load(yaml_str))
 
-		validation_result = await self.validate_output(yaml_str, validator, reconciliation_prompt)
+		validation_result = await self.validate_output(final_rules_md, validator, reconciliation_prompt)
 		write_rules_yaml(self._paths.target_path, yaml.dump(validation_result.model_dump()))
+
+

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -67,7 +67,7 @@ class RulesAdapter(AdapterBase):
 			},
 			'docs': context.docs,
 			'golden_files': [
-				{'path': score.path, 'content': Path(score.path).read_text()} for score in top_files
+				{'path': score.path, 'content': (Path(self._paths.target_path) / score.path).read_text()} for score in top_files
 			],
 		}
 
@@ -83,7 +83,7 @@ class RulesAdapter(AdapterBase):
 			'domain': domain,
 			'extracted_rules': extracted_rules,
 			'golden_files': [
-				{'path': score.path, 'content': Path(score.path).read_text()} for score in top_files
+				{'path': score.path, 'content': (Path(self._paths.target_path) / score.path).read_text()} for score in top_files
 			],
 			'docs': context.docs,
 		}

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -19,7 +19,6 @@ from compass.storage.analysis_context_store import read_analysis_context
 from compass.storage.output_writer import write_rules_md, write_rules_yaml
 
 
-
 class RulesAdapter(AdapterBase):
 	name = 'rules'
 
@@ -56,7 +55,11 @@ class RulesAdapter(AdapterBase):
 			},
 			'docs': context.docs,
 			'golden_files': [
-				{'path': score.path, 'content': (Path(self._paths.target_path) / score.path).read_text()} for score in top_files
+				{
+					'path': score.path,
+					'content': (Path(self._paths.target_path) / score.path).read_text(),
+				}
+				for score in top_files
 			],
 		}
 
@@ -72,7 +75,11 @@ class RulesAdapter(AdapterBase):
 			'domain': domain,
 			'extracted_rules': extracted_rules,
 			'golden_files': [
-				{'path': score.path, 'content': (Path(self._paths.target_path) / score.path).read_text()} for score in top_files
+				{
+					'path': score.path,
+					'content': (Path(self._paths.target_path) / score.path).read_text(),
+				}
+				for score in top_files
 			],
 			'docs': context.docs,
 		}
@@ -115,7 +122,7 @@ class RulesAdapter(AdapterBase):
 			yaml_str = self.parse_reconciliation_output(raw)
 			return RulesOutput.model_validate(yaml.safe_load(yaml_str))
 
-		validation_result = await self.validate_output(final_rules_md, validator, reconciliation_prompt)
+		validation_result = await self.validate_output(
+			final_rules_md, validator, reconciliation_prompt
+		)
 		write_rules_yaml(self._paths.target_path, yaml.dump(validation_result.model_dump()))
-
-

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -13,9 +13,11 @@ from compass.domain.analysis_context import AnalysisContext
 from compass.domain.file_score import FileScore
 from compass.language_detection import detect
 from compass.prompts.loader import load_template
+from compass.repomix import run_repomix
 from compass.schemas.rules_schema import RulesOutput
 from compass.storage.analysis_context_store import read_analysis_context
 from compass.storage.output_writer import write_rules_md, write_rules_yaml
+
 
 
 class RulesAdapter(AdapterBase):
@@ -26,19 +28,6 @@ class RulesAdapter(AdapterBase):
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
 			:10
 		]
-
-	async def _run_repomix(self, files: list[str]) -> str:
-		if not files:
-			return ''
-		proc = await asyncio.create_subprocess_exec(
-			'repomix',
-			'--compress',
-			*files,
-			stdout=asyncio.subprocess.PIPE,
-			stderr=asyncio.subprocess.PIPE,
-		)
-		stdout, _ = await proc.communicate()
-		return stdout.decode()
 
 	def build_prompt(
 		self, context: AnalysisContext, skeletons: str, repomix_bodies: str, domain: str, lang: str
@@ -107,7 +96,7 @@ class RulesAdapter(AdapterBase):
 
 		skeletons, repomix_bodies = await asyncio.gather(
 			self.run_grep_ast(files),
-			self._run_repomix(files),
+			run_repomix(files, Path(self._paths.target_path)),
 		)
 		repo_name = Path(self._paths.target_path).name
 		extraction_prompt = self.build_prompt(

--- a/compass/cli.py
+++ b/compass/cli.py
@@ -8,10 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-try:
-	import yaml
-except ImportError:  # pragma: no cover - exercised only in minimal local environments.
-	yaml = None
+import yaml
 
 from compass.config import CompassConfig
 from compass.errors import CompassError, ConfigError
@@ -142,19 +139,7 @@ def _load_config_file(path: Path) -> dict[str, Any]:
 
 
 def _parse_config_text(content: str) -> dict[str, Any] | None:
-	if yaml is not None:
-		return yaml.safe_load(content)
-
-	data: dict[str, str] = {}
-	for raw_line in content.splitlines():
-		line = raw_line.strip()
-		if not line or line.startswith('#'):
-			continue
-		if ':' not in line:
-			raise ConfigError('config.yaml', raw_line, 'simple "key: value" entries')
-		key, value = line.split(':', maxsplit=1)
-		data[key.strip()] = value.strip()
-	return data or None
+	return yaml.safe_load(content)
 
 
 def _validate_config_keys(path: Path, data: dict[str, Any]) -> None:

--- a/compass/cli.py
+++ b/compass/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 try:
-	import yaml  # type: ignore[import-untyped]
+	import yaml
 except ImportError:  # pragma: no cover - exercised only in minimal local environments.
 	yaml = None
 

--- a/compass/prompts/templates/reconciliation.md
+++ b/compass/prompts/templates/reconciliation.md
@@ -258,3 +258,18 @@ a conservative, predictable gate — not a second extraction pass.
 - **Do not merge cross-domain duplicates.** Cross-reference them instead.
 - **Do not re-validate in `--after-all` mode.** The final merge pass operates
   only on already-validated per-batch output.
+
+---
+
+## Output Instructions
+
+Your final answer must end with the following block. No text after it.
+
+### FINAL YAML OUTPUT ###
+
+```yaml
+clusters:
+  your_cluster_name:
+    - "rule one"
+    - "rule two"
+```

--- a/compass/prompts/templates/reconciliation.md
+++ b/compass/prompts/templates/reconciliation.md
@@ -269,7 +269,12 @@ Your final answer must end with the following block. No text after it.
 
 ```yaml
 clusters:
-  your_cluster_name:
-    - "rule one"
-    - "rule two"
+  - name: Phase Boundary
+    context: One sentence describing what this cluster governs.
+    golden_file: src/compass/collectors/base.py
+    rules:
+      - id: pb-01
+        rule: Collectors must never import or call LLM code.
+        why: Phase 1 is zero-LLM by design.
+        example: "class RepomixCollector: ..."
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
   "pytest-cov>=5.0",
   "ruff>=0.4",
   "types-networkx",
+  "types-PyYAML",
 ]
 
 [project.scripts]

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from compass.adapters.rules import RulesAdapter
+from compass.config import CompassConfig
+from compass.paths import compass_paths
+
+
+def _config() -> CompassConfig:
+	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
+
+
+@pytest.fixture
+def adapter(tmp_path):
+	config = _config()
+	with patch('compass.adapters.base.get_provider') as mock_get:
+		mock_provider = MagicMock()
+		mock_provider.call = AsyncMock(return_value='provider response')
+		mock_get.return_value = mock_provider
+		inst = RulesAdapter(config, compass_paths(tmp_path))
+		inst._provider = mock_provider
+		return inst
+
+
+# --- parse_reconciliation_output ---
+
+
+def test_parse_reconciliation_output_success(adapter):
+	raw = 'Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - "Always use explicit types"\n```\n'
+
+	result = adapter.parse_reconciliation_output(raw)
+
+	assert 'clusters:' in result
+	assert 'Always use explicit types' in result
+
+
+def test_parse_reconciliation_output_raises_on_missing_header(adapter):
+	raw = 'Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n'
+
+	with pytest.raises(ValueError, match='missing strict section header'):
+		adapter.parse_reconciliation_output(raw)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -9,50 +9,35 @@ from compass.paths import compass_paths
 
 
 def _config() -> CompassConfig:
-    return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
+	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
 
 
 @pytest.fixture
 def adapter(tmp_path):
-    config = _config()
-    with patch('compass.adapters.base.get_provider') as mock_get:
-        mock_provider = MagicMock()
-        mock_provider.call = AsyncMock(return_value='provider response')
-        mock_get.return_value = mock_provider
-        inst = RulesAdapter(config, compass_paths(tmp_path))
-        inst._provider = mock_provider
-        return inst
+	config = _config()
+	with patch('compass.adapters.base.get_provider') as mock_get:
+		mock_provider = MagicMock()
+		mock_provider.call = AsyncMock(return_value='provider response')
+		mock_get.return_value = mock_provider
+		inst = RulesAdapter(config, compass_paths(tmp_path))
+		inst._provider = mock_provider
+		return inst
 
 
 # --- parse_reconciliation_output ---
 
 
 def test_parse_reconciliation_output_success(adapter):
-    valid_llm_response = """
-    Some analysis text from the LLM.
+	raw = "Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - \"Always use explicit types\"\n```\n"
 
-    ### FINAL YAML OUTPUT ###
-    ```yaml
-    clusters:
-      typing:
-        - "Always use explicit types"
-    ```
-    """
+	result = adapter.parse_reconciliation_output(raw)
 
-    result = adapter.parse_reconciliation_output(valid_llm_response)
-
-    assert "clusters:" in result
-    assert "Always use explicit types" in result
+	assert "clusters:" in result
+	assert "Always use explicit types" in result
 
 
 def test_parse_reconciliation_output_raises_on_missing_header(adapter):
-    invalid_llm_response = """
-    Here is the yaml you asked for:
-    ```yaml
-    clusters:
-      typing: []
-    ```
-    """
+	raw = "Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n"
 
-    with pytest.raises(ValueError, match="missing strict section header"):
-        adapter.parse_reconciliation_output(invalid_llm_response)
+	with pytest.raises(ValueError, match="missing strict section header"):
+		adapter.parse_reconciliation_output(raw)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -12,8 +12,6 @@ from compass.domain.analysis_context import (
 	ArchitectureSnapshot,
 	GitPatternsSnapshot,
 )
-from compass.domain.cluster import Cluster
-from compass.domain.coupling_pair import CouplingPair
 from compass.domain.file_score import FileScore
 from compass.errors import SchemaValidationError
 from compass.paths import compass_paths

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from compass.adapters.rules import RulesAdapter
+from compass.config import CompassConfig
+from compass.paths import compass_paths
+
+
+def _config() -> CompassConfig:
+    return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    config = _config()
+    with patch('compass.adapters.base.get_provider') as mock_get:
+        mock_provider = MagicMock()
+        mock_provider.call = AsyncMock(return_value='provider response')
+        mock_get.return_value = mock_provider
+        inst = RulesAdapter(config, compass_paths(tmp_path))
+        inst._provider = mock_provider
+        return inst
+
+
+# --- parse_reconciliation_output ---
+
+
+def test_parse_reconciliation_output_success(adapter):
+    valid_llm_response = """
+    Some analysis text from the LLM.
+
+    ### FINAL YAML OUTPUT ###
+    ```yaml
+    clusters:
+      typing:
+        - "Always use explicit types"
+    ```
+    """
+
+    result = adapter.parse_reconciliation_output(valid_llm_response)
+
+    assert "clusters:" in result
+    assert "Always use explicit types" in result
+
+
+def test_parse_reconciliation_output_raises_on_missing_header(adapter):
+    invalid_llm_response = """
+    Here is the yaml you asked for:
+    ```yaml
+    clusters:
+      typing: []
+    ```
+    """
+
+    with pytest.raises(ValueError, match="missing strict section header"):
+        adapter.parse_reconciliation_output(invalid_llm_response)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -28,16 +28,16 @@ def adapter(tmp_path):
 
 
 def test_parse_reconciliation_output_success(adapter):
-	raw = "Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - \"Always use explicit types\"\n```\n"
+	raw = 'Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - "Always use explicit types"\n```\n'
 
 	result = adapter.parse_reconciliation_output(raw)
 
-	assert "clusters:" in result
-	assert "Always use explicit types" in result
+	assert 'clusters:' in result
+	assert 'Always use explicit types' in result
 
 
 def test_parse_reconciliation_output_raises_on_missing_header(adapter):
-	raw = "Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n"
+	raw = 'Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n'
 
-	with pytest.raises(ValueError, match="missing strict section header"):
+	with pytest.raises(ValueError, match='missing strict section header'):
 		adapter.parse_reconciliation_output(raw)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from compass.adapters.rules import RulesAdapter
+from compass.config import CompassConfig
+from compass.domain.analysis_context import (
+	AnalysisContext,
+	ArchitectureSnapshot,
+	GitPatternsSnapshot,
+)
+from compass.domain.cluster import Cluster
+from compass.domain.coupling_pair import CouplingPair
+from compass.domain.file_score import FileScore
+from compass.errors import SchemaValidationError
+from compass.paths import compass_paths
+from compass.schemas.rules_schema import RulesOutput
+
+
+def _config() -> CompassConfig:
+	return CompassConfig(target_path='/tmp/repo', adapters=['rules'], provider='claude')
+
+
+def _make_context(tmp_path) -> AnalysisContext:
+	fake_file = tmp_path / 'path.py'
+	fake_file.write_text('def foo(): pass')
+	return AnalysisContext(
+		architecture=ArchitectureSnapshot(
+			file_scores=[
+				FileScore(
+					path=str(fake_file),
+					churn=0.89,
+					age=62,
+					centrality=0.3,
+					cluster_id=5,
+					coupling_pairs=('this/is/path/2.py', 'this/is/path/1.py'),
+				)
+			],
+			coupling_pairs=[],
+			clusters=[],
+		),
+		patterns={
+			'error_handling': ['except ValueError as e: raise ValidationError(str(e)) from e']
+		},
+		git_patterns=GitPatternsSnapshot(
+			hotspots=['src/main.py'], stable_files=['src/config.py'], coupling_clusters=[]
+		),
+		docs={'codestyle': 'this is code'},
+	)
+
+
+def _valid_yaml() -> str:
+	return """clusters:
+  - name: Error Handling
+    context: How errors are handled
+    golden_file: src/main.py
+    rules:
+      - id: err-01
+        rule: Always catch specific exceptions
+        why: Broad catches hide bugs
+        example: except ValueError
+"""
+
+
+@pytest.fixture
+def adapter(tmp_path):
+	config = _config()
+	with patch('compass.adapters.base.get_provider') as mock_get:
+		mock_provider = MagicMock()
+		mock_provider.call = AsyncMock(return_value='provider response')
+		mock_get.return_value = mock_provider
+		inst = RulesAdapter(config, compass_paths(tmp_path))
+		inst._provider = mock_provider
+		return inst
+
+
+# --- parse_reconciliation_output ---
+
+
+def test_parse_reconciliation_output_success(adapter):
+	raw = 'Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - "Always use explicit types"\n```\n'
+
+	result = adapter.parse_reconciliation_output(raw)
+
+	assert 'clusters:' in result
+	assert 'Always use explicit types' in result
+
+
+def test_parse_reconciliation_output_raises_on_missing_header(adapter):
+	raw = 'Here is the yaml:\n```yaml\nclusters:\n  typing: []\n```\n'
+
+	with pytest.raises(ValueError, match='missing strict section header'):
+		adapter.parse_reconciliation_output(raw)
+
+
+def test_build_prompt(adapter, tmp_path):
+	fake_analysis_context = _make_context(tmp_path)
+	prompt = adapter.build_prompt(
+		fake_analysis_context,
+		skeletons='def foo(): pass',
+		repomix_bodies='class Bar: ...',
+		domain='myrepo',
+		lang='python',
+	)
+
+	assert 'def foo(): pass' in prompt
+	assert 'class Bar: ...' in prompt
+	assert 'error_handling' in prompt
+	assert 'except ValueError' in prompt
+	assert 'src/config.py' in prompt
+	assert 'codestyle' in prompt
+	assert 'this is code' in prompt
+	assert str(tmp_path / 'path.py') in prompt
+
+
+async def test_validate_output_passes_valid_schema(adapter):
+	adapter.call_provider = AsyncMock(return_value=_valid_yaml())
+
+	def validator(raw: str):
+		return RulesOutput.model_validate(yaml.safe_load(raw))
+
+	result = await adapter.validate_output(_valid_yaml(), validator, 'prompt')
+
+	assert result is not None
+
+
+async def test_validate_output_retires_once_on_invalid(adapter):
+	adapter.call_provider = AsyncMock(side_effect=[_valid_yaml()])
+
+	def validator(raw: str):
+		return RulesOutput.model_validate(yaml.safe_load(raw))
+
+	with patch('asyncio.sleep', new_callable=AsyncMock):
+		result = await adapter.validate_output('invalid yaml', validator, 'prompt')
+
+	assert result is not None
+	adapter.call_provider.assert_called_once()
+
+
+async def test_validate_output_hard_error_after_second_failure(adapter):
+	adapter.call_provider = AsyncMock(side_effect=['invalid yaml'])
+
+	def validator(raw: str):
+		return RulesOutput.model_validate(yaml.safe_load(raw))
+
+	with patch('asyncio.sleep', new_callable=AsyncMock):
+		with pytest.raises(SchemaValidationError):
+			await adapter.validate_output('invalid yaml', validator, 'prompt')

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -78,12 +78,26 @@ def adapter(tmp_path):
 
 
 def test_parse_reconciliation_output_success(adapter):
-	raw = 'Some text.\n\n### FINAL YAML OUTPUT ###\n```yaml\nclusters:\n  typing:\n    - "Always use explicit types"\n```\n'
+	raw = (
+		'Some text.\n\n'
+		'### FINAL YAML OUTPUT ###\n'
+		'```yaml\n'
+		'clusters:\n'
+		'  - name: Error Handling\n'
+		'    context: How errors are handled across the codebase\n'
+		'    golden_file: src/main.py\n'
+		'    rules:\n'
+		'      - id: err-01\n'
+		'        rule: Always catch specific exceptions\n'
+		'        why: Broad catches hide bugs\n'
+		'        example: "except ValueError as e"\n'
+		'```\n'
+	)
 
 	result = adapter.parse_reconciliation_output(raw)
 
 	assert 'clusters:' in result
-	assert 'Always use explicit types' in result
+	assert 'err-01' in result
 
 
 def test_parse_reconciliation_output_raises_on_missing_header(adapter):

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -7,11 +7,10 @@ import yaml
 
 from compass.adapters.rules import RulesAdapter
 from compass.config import CompassConfig
-from compass.domain.analysis_context import (
-	AnalysisContext,
-	ArchitectureSnapshot,
-	GitPatternsSnapshot,
-)
+from compass.domain.analysis_context import AnalysisContext
+from compass.domain.architecture_snapshot import ArchitectureSnapshot
+from compass.domain.git_patterns_snapshot import GitPatternsSnapshot
+
 from compass.domain.file_score import FileScore
 from compass.errors import SchemaValidationError
 from compass.paths import compass_paths


### PR DESCRIPTION
## Summary
- Implement RulesAdapter with two-pass LLM synthesis (extraction + reconciliation)
- build_prompt() assembles all six context sections: grep_ast skeletons, repomix bodies, ast-grep patterns, git signals, docs, centrality/clustering
- Two LLM calls: extraction → intermediate rules.md, reconciliation → final rules.md → rules.yaml
- Deterministic parser anchored to ### FINAL YAML OUTPUT ### section header in reconciliation.md
- validate_output() enforces schema with one retry before hard error
- Register RulesAdapter in ADAPTER_REGISTRY

## Test plan
- test_build_prompt: assert all six context sections present in prompt
- test_parse_reconciliation_output: happy path and missing header
- test_validate_output_passes_valid_schema
- test_validate_output_retries_once_on_invalid
- test_validate_output_hard_error_after_second_failure


 Note: pre-existing mypy error in cli.py (unrelated to this PR)

closes #30 