### PR TITLE
[Phase 2] Wire runner.py end-to-end #58

### DIFF
--- a/compass/adapters/base.py
+++ b/compass/adapters/base.py
@@ -14,6 +14,7 @@ from compass.paths import CompassPaths
 from compass.providers.base import BaseProvider, get_provider
 
 
+
 class AdapterBase(ABC):
 	name: str
 

--- a/compass/adapters/base.py
+++ b/compass/adapters/base.py
@@ -6,7 +6,10 @@ from collections.abc import Callable
 from typing import Any
 
 from compass.config import CompassConfig, VALIDATION_RETRY_DELAY
+from compass.domain.analysis_context import AnalysisContext
 from compass.errors import ProviderError, SchemaValidationError
+from compass.file_selector import FileSelectionCriteria, select_files
+from compass.language_detection import DetectedLanguage
 from compass.paths import CompassPaths
 from compass.providers.base import BaseProvider, get_provider
 
@@ -22,9 +25,13 @@ class AdapterBase(ABC):
 	@abstractmethod
 	async def run(self) -> None: ...
 
-	def run_file_selector(self, criteria: dict[str, Any]) -> list[str]:
-		# Stubbed until issue #20 (FileSelector) is ready.
-		return []
+	def run_file_selector(
+		self,
+		context: AnalysisContext,
+		criteria: FileSelectionCriteria,
+		language: DetectedLanguage,
+	) -> list[str]:
+		return select_files(context, criteria, language)
 
 	async def run_grep_ast(self, files: list[str]) -> str:
 		if not files:

--- a/compass/adapters/base.py
+++ b/compass/adapters/base.py
@@ -14,7 +14,6 @@ from compass.paths import CompassPaths
 from compass.providers.base import BaseProvider, get_provider
 
 
-
 class AdapterBase(ABC):
 	name: str
 

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -17,6 +17,7 @@ from compass.repomix import run_repomix
 from compass.schemas.rules_schema import RulesOutput
 from compass.storage.analysis_context_store import read_analysis_context
 from compass.storage.output_writer import write_rules_md, write_rules_yaml
+from compass.file_selector import RULES_SELECTION_CRITERIA
 
 
 class RulesAdapter(AdapterBase):
@@ -99,7 +100,7 @@ class RulesAdapter(AdapterBase):
 	async def run(self) -> None:
 		context = read_analysis_context(self._paths.target_path)
 		language = detect(self._paths.target_path, self._config.lang)
-		files = self.run_file_selector({})
+		files = self.run_file_selector(context, RULES_SELECTION_CRITERIA, language)
 
 		skeletons, repomix_bodies = await asyncio.gather(
 			self.run_grep_ast(files),

--- a/compass/adapters/summary.py
+++ b/compass/adapters/summary.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from compass.adapters.base import AdapterBase
 from compass.domain.analysis_context import AnalysisContext
 from compass.errors import AdapterError, SkeletonError
-from compass.file_selector import SUMMARY_SELECTION_CRITERIA, select_files
+from compass.file_selector import SUMMARY_SELECTION_CRITERIA
 from compass.language_detection import detect
 from compass.prompts.loader import load_template
 from compass.schemas.summary_schema import validate_summary
@@ -93,7 +93,7 @@ class SummaryAdapter(AdapterBase):
 		except (FileNotFoundError, json.JSONDecodeError, ValueError) as exc:
 			raise AdapterError(self.name, f'failed to read analysis context: {exc}') from exc
 		lang = detect(str(self._paths.target_path), self._config.lang)
-		selected_files = select_files(context, SUMMARY_SELECTION_CRITERIA, lang)
+		selected_files = self.run_file_selector(context, SUMMARY_SELECTION_CRITERIA, lang)
 		abs_files = [str(self._paths.target_path / p) for p in selected_files]
 		try:
 			abs_skeletons = render_skeletons(abs_files)

--- a/tests/unit/test_adapter_base.py
+++ b/tests/unit/test_adapter_base.py
@@ -36,16 +36,15 @@ def adapter(tmp_path):
 
 
 def test_run_file_selector_delegates_to_select_files(adapter):
-    context = MagicMock()
-    criteria = MagicMock()
-    expected = ['src/app.py', 'src/utils.py']
+	context = MagicMock()
+	criteria = MagicMock()
+	expected = ['src/app.py', 'src/utils.py']
 
-    with patch('compass.adapters.base.select_files', return_value=expected) as mock_select:
-        result = adapter.run_file_selector(context, criteria, 'python')
+	with patch('compass.adapters.base.select_files', return_value=expected) as mock_select:
+		result = adapter.run_file_selector(context, criteria, 'python')
 
-    mock_select.assert_called_once_with(context, criteria, 'python')
-    assert result == expected
-
+	mock_select.assert_called_once_with(context, criteria, 'python')
+	assert result == expected
 
 
 # --- call_provider ---

--- a/tests/unit/test_adapter_base.py
+++ b/tests/unit/test_adapter_base.py
@@ -35,9 +35,17 @@ def adapter(tmp_path):
 # --- run_file_selector ---
 
 
-def test_run_file_selector_returns_empty_list(adapter):
-	result = adapter.run_file_selector({'type': 'high_centrality'})
-	assert result == []
+def test_run_file_selector_delegates_to_select_files(adapter):
+    context = MagicMock()
+    criteria = MagicMock()
+    expected = ['src/app.py', 'src/utils.py']
+
+    with patch('compass.adapters.base.select_files', return_value=expected) as mock_select:
+        result = adapter.run_file_selector(context, criteria, 'python')
+
+    mock_select.assert_called_once_with(context, criteria, 'python')
+    assert result == expected
+
 
 
 # --- call_provider ---

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -4,6 +4,7 @@ import asyncio
 from pathlib import Path
 
 import pytest
+from unittest.mock import MagicMock
 
 from compass.adapters.base import AdapterBase
 from compass.config import CompassConfig
@@ -14,6 +15,7 @@ from compass.domain.coupling_pair import CouplingPair
 from compass.domain.file_score import FileScore
 from compass.domain.git_patterns_snapshot import GitPatternsSnapshot
 from compass.errors import AdapterError, CollectorError
+from compass.file_selector import RULES_SELECTION_CRITERIA
 from compass.paths import CompassPaths, compass_paths
 from compass.runner import (
 	_build_orchestrator,
@@ -376,17 +378,15 @@ def test_run_adapters_reaches_file_selector(
 		return []
 
 	monkeypatch.setattr('compass.adapters.base.select_files', fake_select_files)
+	monkeypatch.setattr('compass.adapters.base.get_provider', MagicMock(return_value=MagicMock()))
 
 	class FakeAdapter(AdapterBase):
 		name = 'rules'
 
 		def __init__(self, cfg: CompassConfig, paths: CompassPaths) -> None:
-			self._config = cfg
-			self._paths = paths
+			super().__init__(cfg, paths)
 
 		async def run(self) -> None:
-			from compass.file_selector import RULES_SELECTION_CRITERIA
-
 			self.run_file_selector(analysis_context, RULES_SELECTION_CRITERIA, 'python')
 
 	class FakeOrchestrator:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,5 +1,3 @@
-"""Unit tests for the Compass runner."""
-
 from __future__ import annotations
 
 import asyncio
@@ -7,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from compass.adapters.base import AdapterBase
 from compass.config import CompassConfig
 from compass.domain.analysis_context import AnalysisContext
 from compass.domain.architecture_snapshot import ArchitectureSnapshot
@@ -15,12 +14,15 @@ from compass.domain.coupling_pair import CouplingPair
 from compass.domain.file_score import FileScore
 from compass.domain.git_patterns_snapshot import GitPatternsSnapshot
 from compass.errors import AdapterError, CollectorError
+from compass.paths import CompassPaths, compass_paths
 from compass.runner import (
-	_build_orchestrator,
-	_call_async_method,
-	_collect_analysis_context,
-	run,
+    _build_orchestrator,
+    _call_async_method,
+    _collect_analysis_context,
+    _run_adapters,
+    run,
 )
+
 
 
 def _build_analysis_context() -> AnalysisContext:
@@ -354,3 +356,51 @@ def test_call_async_method_does_not_await_plain_awaitable_object() -> None:
 	result = asyncio.run(_call_async_method(FakeInstance(), 'build'))
 
 	assert isinstance(result, PlainAwaitable)
+
+
+def test_run_adapters_reaches_file_selector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = CompassConfig(
+        target_path=str(tmp_path),
+        adapters=['rules'],
+        provider='claude',
+        lang='python',
+        reanalyze=False,
+    )
+    analysis_context = _build_analysis_context()
+    selector_calls: list[str] = []
+
+    def fake_select_files(ctx: object, criteria: object, lang: str) -> list[str]:
+        selector_calls.append(lang)
+        return []
+
+    monkeypatch.setattr('compass.adapters.base.select_files', fake_select_files)
+
+    class FakeAdapter(AdapterBase):
+        name = 'rules'
+
+        def __init__(self, cfg: CompassConfig, paths:CompassPaths ) -> None:
+            self._config = cfg
+            self._paths = paths
+
+        async def run(self) -> None:
+            from compass.file_selector import RULES_SELECTION_CRITERIA
+            self.run_file_selector(analysis_context, RULES_SELECTION_CRITERIA, 'python')
+
+    class FakeOrchestrator:
+        def __init__(self, *, config: CompassConfig, language: str) -> None:
+            pass
+
+        async def run(self, ctx: object) -> list[str]:
+            adapter = FakeAdapter(config, compass_paths(tmp_path))
+            await adapter.run()
+            return ['rules']
+
+    monkeypatch.setattr('compass.runner._load_adapter_orchestrator', lambda: FakeOrchestrator)
+
+    result = asyncio.run(_run_adapters(config, analysis_context, 'python'))
+
+    assert selector_calls == ['python']
+    assert result == ['rules']

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -16,13 +16,12 @@ from compass.domain.git_patterns_snapshot import GitPatternsSnapshot
 from compass.errors import AdapterError, CollectorError
 from compass.paths import CompassPaths, compass_paths
 from compass.runner import (
-    _build_orchestrator,
-    _call_async_method,
-    _collect_analysis_context,
-    _run_adapters,
-    run,
+	_build_orchestrator,
+	_call_async_method,
+	_collect_analysis_context,
+	_run_adapters,
+	run,
 )
-
 
 
 def _build_analysis_context() -> AnalysisContext:
@@ -359,48 +358,49 @@ def test_call_async_method_does_not_await_plain_awaitable_object() -> None:
 
 
 def test_run_adapters_reaches_file_selector(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+	tmp_path: Path,
+	monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    config = CompassConfig(
-        target_path=str(tmp_path),
-        adapters=['rules'],
-        provider='claude',
-        lang='python',
-        reanalyze=False,
-    )
-    analysis_context = _build_analysis_context()
-    selector_calls: list[str] = []
+	config = CompassConfig(
+		target_path=str(tmp_path),
+		adapters=['rules'],
+		provider='claude',
+		lang='python',
+		reanalyze=False,
+	)
+	analysis_context = _build_analysis_context()
+	selector_calls: list[str] = []
 
-    def fake_select_files(ctx: object, criteria: object, lang: str) -> list[str]:
-        selector_calls.append(lang)
-        return []
+	def fake_select_files(ctx: object, criteria: object, lang: str) -> list[str]:
+		selector_calls.append(lang)
+		return []
 
-    monkeypatch.setattr('compass.adapters.base.select_files', fake_select_files)
+	monkeypatch.setattr('compass.adapters.base.select_files', fake_select_files)
 
-    class FakeAdapter(AdapterBase):
-        name = 'rules'
+	class FakeAdapter(AdapterBase):
+		name = 'rules'
 
-        def __init__(self, cfg: CompassConfig, paths:CompassPaths ) -> None:
-            self._config = cfg
-            self._paths = paths
+		def __init__(self, cfg: CompassConfig, paths: CompassPaths) -> None:
+			self._config = cfg
+			self._paths = paths
 
-        async def run(self) -> None:
-            from compass.file_selector import RULES_SELECTION_CRITERIA
-            self.run_file_selector(analysis_context, RULES_SELECTION_CRITERIA, 'python')
+		async def run(self) -> None:
+			from compass.file_selector import RULES_SELECTION_CRITERIA
 
-    class FakeOrchestrator:
-        def __init__(self, *, config: CompassConfig, language: str) -> None:
-            pass
+			self.run_file_selector(analysis_context, RULES_SELECTION_CRITERIA, 'python')
 
-        async def run(self, ctx: object) -> list[str]:
-            adapter = FakeAdapter(config, compass_paths(tmp_path))
-            await adapter.run()
-            return ['rules']
+	class FakeOrchestrator:
+		def __init__(self, *, config: CompassConfig, language: str) -> None:
+			pass
 
-    monkeypatch.setattr('compass.runner._load_adapter_orchestrator', lambda: FakeOrchestrator)
+		async def run(self, ctx: object) -> list[str]:
+			adapter = FakeAdapter(config, compass_paths(tmp_path))
+			await adapter.run()
+			return ['rules']
 
-    result = asyncio.run(_run_adapters(config, analysis_context, 'python'))
+	monkeypatch.setattr('compass.runner._load_adapter_orchestrator', lambda: FakeOrchestrator)
 
-    assert selector_calls == ['python']
-    assert result == ['rules']
+	result = asyncio.run(_run_adapters(config, analysis_context, 'python'))
+
+	assert selector_calls == ['python']
+	assert result == ['rules']

--- a/tests/unit/test_summary_adapter.py
+++ b/tests/unit/test_summary_adapter.py
@@ -185,7 +185,7 @@ async def test_run_writes_summary_md(adapter, tmp_path):
 	with (
 		patch('compass.adapters.summary.read_analysis_context', return_value=context),
 		patch('compass.adapters.summary.detect', return_value='python'),
-		patch('compass.adapters.summary.select_files', return_value=['src/main.py']),
+		patch('compass.adapters.base.select_files', return_value=['src/main.py']),
 		patch('compass.adapters.summary.render_skeletons', return_value={}),
 		patch.object(
 			adapter, 'call_provider', new_callable=AsyncMock, return_value=_VALID_SUMMARY_RESPONSE
@@ -205,7 +205,7 @@ async def test_run_writes_summary_json(adapter, tmp_path):
 	with (
 		patch('compass.adapters.summary.read_analysis_context', return_value=context),
 		patch('compass.adapters.summary.detect', return_value='python'),
-		patch('compass.adapters.summary.select_files', return_value=['src/main.py']),
+		patch('compass.adapters.base.select_files', return_value=['src/main.py']),
 		patch('compass.adapters.summary.render_skeletons', return_value={}),
 		patch.object(
 			adapter, 'call_provider', new_callable=AsyncMock, return_value=_VALID_SUMMARY_RESPONSE
@@ -235,7 +235,7 @@ async def test_run_raises_adapter_error_on_skeleton_error(adapter, tmp_path):
 	with (
 		patch('compass.adapters.summary.read_analysis_context', return_value=context),
 		patch('compass.adapters.summary.detect', return_value='python'),
-		patch('compass.adapters.summary.select_files', return_value=['src/main.py']),
+		patch('compass.adapters.base.select_files', return_value=['src/main.py']),
 		patch(
 			'compass.adapters.summary.render_skeletons',
 			side_effect=SkeletonError('no supported files found'),
@@ -260,7 +260,7 @@ async def test_run_retries_once_on_invalid_response(adapter, tmp_path):
 	with (
 		patch('compass.adapters.summary.read_analysis_context', return_value=context),
 		patch('compass.adapters.summary.detect', return_value='python'),
-		patch('compass.adapters.summary.select_files', return_value=['src/main.py']),
+		patch('compass.adapters.base.select_files', return_value=['src/main.py']),
 		patch('compass.adapters.summary.render_skeletons', return_value={}),
 		patch.object(adapter, 'call_provider', side_effect=fake_provider),
 		patch('asyncio.sleep', new_callable=AsyncMock),
@@ -276,7 +276,7 @@ async def test_run_raises_schema_error_after_second_failure(adapter, tmp_path):
 	with (
 		patch('compass.adapters.summary.read_analysis_context', return_value=context),
 		patch('compass.adapters.summary.detect', return_value='python'),
-		patch('compass.adapters.summary.select_files', return_value=['src/main.py']),
+		patch('compass.adapters.base.select_files', return_value=['src/main.py']),
 		patch('compass.adapters.summary.render_skeletons', return_value={}),
 		patch.object(
 			adapter, 'call_provider', new_callable=AsyncMock, return_value='no json block here'


### PR DESCRIPTION
Replace the `run_file_selector` stub in `AdapterBase` with a real call to
`select_files`. Both adapters now pass their per-adapter criteria as defined
in FINAL.md.

## Changes

- `AdapterBase.run_file_selector` now delegates to `select_files` with
  `AnalysisContext`, `FileSelectionCriteria`, and `DetectedLanguage`
- `RulesAdapter` passes `RULES_SELECTION_CRITERIA` (low-churn +
  high-centrality + high-coupling-pairs)
- `SummaryAdapter` routes through `run_file_selector` instead of calling
  `select_files` directly
- Tests updated: `test_adapter_base`, `test_runner` (wired flow),
  `test_summary_adapter` (patch path corrected)

## Test plan
- [ ] `python3 -m pytest` → 123 passed
- [ ] `python3 -m ruff check . && python3 -m mypy .` → clean