### PR TITLE
ci: finalize pipeline — continue-on-error + integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Run Ruff (format check)
         run: |
           ruff format --check .
-      # TODO: Make config file (pyproject.toml)
 
   type-check:
     name: Type Checking
@@ -54,12 +53,10 @@ jobs:
       - name: Run mypy
         run: |
           mypy .
-      # TODO: add config file (mypy.ini) later
 
   security:
     name: Security Scan
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -97,15 +94,22 @@ jobs:
           pytest
       # no tests yet
 
-  code-quality:
-    name: Code Quality Platform (TBA)
+  integration-tests:
+    name: Integration Tests
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Placeholder for Code Quality Tool
-        run: echo "Code quality integration comes later"
-      # TODO: integrate SonarCube/SonarCloud or Codecov
-      # needs secrets like SONAR_TOKEN
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: |
+          pytest tests/integration/ -m integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,4 +121,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --run-integration tests/integration/
+          pytest tests/integration/ -m integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -110,6 +111,14 @@ jobs:
         run: |
           pip install -e ".[dev]"
 
+      - name: Install integration test binaries
+        run: |
+          npm install -g @ast-grep/cli repomix
+
+      - name: Configure git safe directory
+        run: |
+          git config --global safe.directory '*'
+
       - name: Run tests
         run: |
-          pytest tests/integration/ -m integration
+          pytest --run-integration tests/integration/

--- a/compass/repomix.py
+++ b/compass/repomix.py
@@ -14,7 +14,8 @@ async def run_repomix(paths: list[str], repo_root: Path) -> str:
 	proc = await asyncio.create_subprocess_exec(
 		'repomix',
 		str(abs_root),
-		'--include', ','.join(paths),
+		'--include',
+		','.join(paths),
 		'--compress',
 		stdout=asyncio.subprocess.PIPE,
 		stderr=asyncio.subprocess.PIPE,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,4 +64,15 @@ def commit_fixture_change(repo_path: Path, relative_path: str, content: str, mes
 	file_path = repo_path / relative_path
 	file_path.write_text(content, encoding='utf-8')
 	subprocess.run(['git', '-C', str(repo_path), 'add', relative_path], check=True)
-	subprocess.run(['git', '-C', str(repo_path), 'commit', '--quiet', '-m', message], check=True)
+	subprocess.run(
+		[
+			'git',
+			'-C', str(repo_path),
+			'-c', 'user.name=Compass Fixtures',
+			'-c', 'user.email=fixtures@compass.local',
+			'commit',
+			'--quiet',
+			'-m', message,
+		],
+		check=True,
+	)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -67,12 +67,16 @@ def commit_fixture_change(repo_path: Path, relative_path: str, content: str, mes
 	subprocess.run(
 		[
 			'git',
-			'-C', str(repo_path),
-			'-c', 'user.name=Compass Fixtures',
-			'-c', 'user.email=fixtures@compass.local',
+			'-C',
+			str(repo_path),
+			'-c',
+			'user.name=Compass Fixtures',
+			'-c',
+			'user.email=fixtures@compass.local',
 			'commit',
 			'--quiet',
-			'-m', message,
+			'-m',
+			message,
 		],
 		check=True,
 	)


### PR DESCRIPTION
## Summary
- Remove placeholder code quality job
- Remove `continue-on-error` so CI fails properly on errors
- Add dedicated integration test job for `tests/integration/`
- Fix integration test hang: add git user config in `commit_fixture_change`
- Add `timeout-minutes: 10` to integration job to catch future hangs
- Install `ast-grep` and `repomix` binaries required by rules/summary tests
- Fix pytest invocation: use `--run-integration` flag (matches conftest hook)
- Add `git config --global safe.directory '*'` for GitHub Actions clone safety

## Root cause of CI hang
`commit_fixture_change` in `conftest.py` called `git commit` without `user.name`/`user.email` configured in the fixture clone. On GitHub Actions (no global git user), git blocks waiting for stdin input that never arrives — causing the job to hang indefinitely. Fixed by passing `-c user.name=... -c user.email=...` directly to the git command.

## Validation
- 128/128 tests pass locally (123 unit + 5 integration)
- Integration tests run with `pytest --run-integration tests/integration/`