### PR TITLE
Improve prerequisite error message formatting and manual install instructions

### DIFF
--- a/compass/errors.py
+++ b/compass/errors.py
@@ -17,7 +17,7 @@ class PrerequisiteError(CompassError):
 
 	def __init__(self, tool: str, reason: str, install_instructions: str) -> None:
 		super().__init__(
-			f'Missing prerequisite: {tool}. {reason} Install with: {install_instructions}.'
+			f'Missing prerequisite: {tool}\n{reason}\n\nInstall with:\n{install_instructions}'
 		)
 
 

--- a/compass/prerequisites.py
+++ b/compass/prerequisites.py
@@ -118,6 +118,27 @@ def _find_codebase_memory_mcp() -> Path | None:
 	return Path(path_location)
 
 
+def _manual_codebase_memory_mcp_install_instructions(download_url: str | None = None) -> str:
+	install_path = '~/.compass/bin/codebase-memory-mcp'
+	if download_url is not None:
+		first_step = f'1. Download the archive from {download_url}'
+	else:
+		first_step = (
+			'1. Open https://github.com/DeusData/codebase-memory-mcp/releases/latest '
+			'and download the archive matching your platform'
+		)
+
+	steps = [
+		first_step,
+		f'2. Extract it - the file named {CODEBASE_MEMORY_MCP} inside is the binary',
+		f'3. Move it to {install_path}',
+		f'4. Run chmod +x {install_path}',
+	]
+	if platform.system() == 'Darwin':
+		steps.append(f'5. Run xattr -d com.apple.quarantine {install_path} to bypass Gatekeeper')
+	return '\n'.join(steps)
+
+
 def _download_codebase_memory_mcp() -> Path:
 	download_url = _codebase_memory_mcp_download_url()
 	target_path = _local_codebase_memory_mcp_path()
@@ -130,10 +151,7 @@ def _download_codebase_memory_mcp() -> Path:
 		raise PrerequisiteError(
 			CODEBASE_MEMORY_MCP,
 			'The auto-download failed while fetching the release archive.',
-			(
-				f'Download the correct archive from {download_url} and place the '
-				f'{CODEBASE_MEMORY_MCP} binary in {target_path.parent}'
-			),
+			_manual_codebase_memory_mcp_install_instructions(download_url),
 		) from error
 
 	try:
@@ -142,10 +160,7 @@ def _download_codebase_memory_mcp() -> Path:
 		raise PrerequisiteError(
 			CODEBASE_MEMORY_MCP,
 			'The downloaded archive could not be unpacked safely.',
-			(
-				f'Download the correct archive from {download_url} and place the '
-				f'{CODEBASE_MEMORY_MCP} binary in {target_path.parent}'
-			),
+			_manual_codebase_memory_mcp_install_instructions(download_url),
 		) from error
 
 	target_path.write_bytes(binary_bytes)
@@ -176,7 +191,7 @@ def _codebase_memory_mcp_download_url() -> str:
 		raise PrerequisiteError(
 			CODEBASE_MEMORY_MCP,
 			f'No supported auto-download is configured for platform {system}/{machine}.',
-			'Download a matching release manually and place it in ~/.compass/bin',
+			_manual_codebase_memory_mcp_install_instructions(),
 		) from error
 
 

--- a/tests/unit/test_prerequisites.py
+++ b/tests/unit/test_prerequisites.py
@@ -173,8 +173,55 @@ def test_check_raises_when_codebase_memory_download_fails(
 
 	monkeypatch.setattr('compass.prerequisites.urlopen', fake_urlopen)
 
-	with pytest.raises(PrerequisiteError, match='auto-download failed'):
+	with pytest.raises(PrerequisiteError) as exc_info:
 		check()
+
+	message = str(exc_info.value)
+	assert 'Missing prerequisite: codebase-memory-mcp' in message
+	assert 'The auto-download failed while fetching the release archive.' in message
+	assert 'Install with:' in message
+	assert '1. Download the archive from ' in message
+	assert '2. Extract it - the file named codebase-memory-mcp inside is the binary' in message
+	assert '3. Move it to ~/.compass/bin/codebase-memory-mcp' in message
+	assert '4. Run chmod +x ~/.compass/bin/codebase-memory-mcp' in message
+	assert (
+		'5. Run xattr -d com.apple.quarantine ~/.compass/bin/codebase-memory-mcp to bypass Gatekeeper'
+		in message
+	)
+
+
+def test_check_raises_when_codebase_memory_download_fails_without_gatekeeper_step_on_linux(
+	tmp_path: Path,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	home_dir = tmp_path / 'home'
+
+	monkeypatch.setattr('compass.prerequisites.Path.home', lambda: home_dir)
+	monkeypatch.setattr(
+		'compass.prerequisites.importlib.util.find_spec',
+		lambda module_name: SimpleNamespace(name=module_name),
+	)
+
+	def fake_which(name: str) -> str | None:
+		if name == 'codebase-memory-mcp':
+			return None
+		return f'/usr/bin/{name}'
+
+	monkeypatch.setattr('compass.prerequisites.which', fake_which)
+	monkeypatch.setattr('compass.prerequisites.platform.system', lambda: 'Linux')
+	monkeypatch.setattr('compass.prerequisites.platform.machine', lambda: 'x86_64')
+
+	def fake_urlopen(url: str, timeout: int) -> io.BytesIO:
+		raise OSError('network down')
+
+	monkeypatch.setattr('compass.prerequisites.urlopen', fake_urlopen)
+
+	with pytest.raises(PrerequisiteError) as exc_info:
+		check()
+
+	message = str(exc_info.value)
+	assert '4. Run chmod +x ~/.compass/bin/codebase-memory-mcp' in message
+	assert 'com.apple.quarantine' not in message
 
 
 def _build_codebase_memory_archive() -> bytes:


### PR DESCRIPTION
## Summary
  - format `PrerequisiteError` output as a readable multi-line message
  - add explicit manual install steps for `codebase-memory-mcp`
  - include extract, `chmod +x`, and macOS Gatekeeper instructions
  - reuse the same install hint for download, unpack, and unsupported-platform failures
  - extend prerequisite tests for Darwin and Linux error output

closes #77 