### PR TITLE
fix(prerequisites): include OSError details in mcp download failure m…

### DIFF
--- a/compass/prerequisites.py
+++ b/compass/prerequisites.py
@@ -171,7 +171,7 @@ def _download_codebase_memory_mcp() -> Path:
 	except OSError as error:
 		raise PrerequisiteError(
 			CODEBASE_MEMORY_MCP,
-			'The auto-download failed while fetching the release archive.',
+			f'The auto-download failed while fetching the release archive: {error}',
 			_manual_codebase_memory_mcp_install_instructions(download_url),
 		) from error
 

--- a/tests/unit/test_prerequisites.py
+++ b/tests/unit/test_prerequisites.py
@@ -178,7 +178,7 @@ def test_check_raises_when_codebase_memory_download_fails(
 
 	message = str(exc_info.value)
 	assert 'Missing prerequisite: codebase-memory-mcp' in message
-	assert 'The auto-download failed while fetching the release archive.' in message
+	assert 'The auto-download failed while fetching the release archive:' in message
 	assert 'Install with:' in message
 	assert '1. Download the archive from ' in message
 	assert '2. Extract it - the file named codebase-memory-mcp inside is the binary' in message

--- a/tests/unit/test_prerequisites.py
+++ b/tests/unit/test_prerequisites.py
@@ -289,7 +289,7 @@ def test_check_raises_when_codebase_memory_download_fails_on_windows(
 
 	message = str(exc_info.value)
 	assert 'Missing prerequisite: codebase-memory-mcp' in message
-	assert 'The auto-download failed while fetching the release archive.' in message
+	assert 'The auto-download failed while fetching the release archive:' in message
 	assert 'Unblock-File' in message
 	assert 'chmod' not in message
 	assert 'com.apple.quarantine' not in message


### PR DESCRIPTION
issue #80 
The original OSError is now included in the user-facing message.