### PR TITLE
Binary files cause UnicodeDecodeError in RulesAdapter and SkeletonError in skeleton.py

### DIFF
--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -24,10 +24,16 @@ class RulesAdapter(AdapterBase):
 	name = 'rules'
 
 	def _top_files(self, context: AnalysisContext) -> list[FileScore]:
-
 		return sorted(context.architecture.file_scores, key=lambda s: s.centrality, reverse=True)[
 			:10
 		]
+
+	def _read_golden_file(self, path: Path, *, limit: int | None = None) -> str | None:
+		try:
+			content = path.read_text(encoding='utf-8')
+		except UnicodeDecodeError:
+			return None
+		return content[:limit] if limit is not None else content
 
 	def build_prompt(
 		self, context: AnalysisContext, skeletons: str, repomix_bodies: str, domain: str, lang: str
@@ -58,11 +64,15 @@ class RulesAdapter(AdapterBase):
 			'golden_files': [
 				{
 					'path': score.path,
-					'content': (Path(self._paths.target_path) / score.path).read_text(
-						encoding='utf-8'
-					)[:5000],
+					'content': content,
 				}
 				for score in top_files
+				if (
+					content := self._read_golden_file(
+						Path(self._paths.target_path) / score.path, limit=5000
+					)
+				)
+				is not None
 				if (Path(self._paths.target_path) / score.path).suffix
 				in {'.py', '.ts', '.tsx', '.js'}
 			],
@@ -82,9 +92,11 @@ class RulesAdapter(AdapterBase):
 			'golden_files': [
 				{
 					'path': score.path,
-					'content': (Path(self._paths.target_path) / score.path).read_text(),
+					'content': content,
 				}
 				for score in top_files
+				if (content := self._read_golden_file(Path(self._paths.target_path) / score.path))
+				is not None
 			],
 			'docs': context.docs,
 		}

--- a/compass/adapters/rules.py
+++ b/compass/adapters/rules.py
@@ -67,14 +67,14 @@ class RulesAdapter(AdapterBase):
 					'content': content,
 				}
 				for score in top_files
+				if (Path(self._paths.target_path) / score.path).suffix
+				in {'.py', '.ts', '.tsx', '.js'}
 				if (
 					content := self._read_golden_file(
 						Path(self._paths.target_path) / score.path, limit=5000
 					)
 				)
 				is not None
-				if (Path(self._paths.target_path) / score.path).suffix
-				in {'.py', '.ts', '.tsx', '.js'}
 			],
 		}
 

--- a/compass/skeleton.py
+++ b/compass/skeleton.py
@@ -10,7 +10,9 @@ def render_skeletons(paths: list[str]) -> dict[str, str]:
 			continue
 		try:
 			code = Path(path).read_text(encoding='utf-8')
-		except (OSError, UnicodeDecodeError) as e:
+		except UnicodeDecodeError:
+			continue
+		except OSError as e:
 			raise SkeletonError(str(e)) from e
 		try:
 			skeleton = _render_grep_ast_skeleton(path, code)

--- a/tests/unit/test_rules_adapter.py
+++ b/tests/unit/test_rules_adapter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -49,6 +51,33 @@ def _make_context(tmp_path) -> AnalysisContext:
 	)
 
 
+def _make_context_with_files(*files: Path) -> AnalysisContext:
+	return AnalysisContext(
+		architecture=ArchitectureSnapshot(
+			file_scores=[
+				FileScore(
+					path=str(file),
+					churn=0.89 - (index * 0.1),
+					age=62,
+					centrality=1.0 - (index * 0.1),
+					cluster_id=5,
+					coupling_pairs=('this/is/path/2.py', 'this/is/path/1.py'),
+				)
+				for index, file in enumerate(files)
+			],
+			coupling_pairs=[],
+			clusters=[],
+		),
+		patterns={
+			'error_handling': ['except ValueError as e: raise ValidationError(str(e)) from e']
+		},
+		git_patterns=GitPatternsSnapshot(
+			hotspots=['src/main.py'], stable_files=['src/config.py'], coupling_clusters=[]
+		),
+		docs={'codestyle': 'this is code'},
+	)
+
+
 def _valid_yaml() -> str:
 	return """clusters:
   - name: Error Handling
@@ -60,6 +89,11 @@ def _valid_yaml() -> str:
         why: Broad catches hide bugs
         example: except ValueError
 """
+
+
+def _prompt_input(prompt: str) -> dict:
+	input_block = prompt.split('## Input\n\n```json\n')[-1]
+	return json.loads(input_block.rsplit('\n```', 1)[0])
 
 
 @pytest.fixture
@@ -125,6 +159,44 @@ def test_build_prompt(adapter, tmp_path):
 	assert 'codestyle' in prompt
 	assert 'this is code' in prompt
 	assert str(tmp_path / 'path.py') in prompt
+
+
+def test_build_prompt_skips_binary_golden_file(adapter, tmp_path):
+	text_file = tmp_path / 'text.py'
+	binary_file = tmp_path / 'binary.py'
+	text_file.write_text('def foo():\n    return 1\n')
+	binary_file.write_bytes(b'\xff\xfe\x00\x00')
+	context = _make_context_with_files(binary_file, text_file)
+
+	prompt = adapter.build_prompt(
+		context,
+		skeletons='def foo(): pass',
+		repomix_bodies='class Bar: ...',
+		domain='myrepo',
+		lang='python',
+	)
+	input_dict = _prompt_input(prompt)
+
+	assert input_dict['golden_files'] == [
+		{'path': str(text_file), 'content': 'def foo():\n    return 1\n'}
+	]
+
+
+def test_build_reconciliation_prompt_skips_binary_golden_file(adapter, tmp_path):
+	text_file = tmp_path / 'text.py'
+	binary_file = tmp_path / 'binary.py'
+	text_file.write_text('def foo():\n    return 1\n')
+	binary_file.write_bytes(b'\xff\xfe\x00\x00')
+	context = _make_context_with_files(binary_file, text_file)
+
+	prompt = adapter.build_reconciliation_prompt(
+		context, extracted_rules='rules', domain='myrepo', lang='python'
+	)
+	input_dict = _prompt_input(prompt)
+
+	assert input_dict['golden_files'] == [
+		{'path': str(text_file), 'content': 'def foo():\n    return 1\n'}
+	]
 
 
 async def test_validate_output_passes_valid_schema(adapter):

--- a/tests/unit/test_skeleton.py
+++ b/tests/unit/test_skeleton.py
@@ -36,6 +36,26 @@ def test_render_skeletons_raises_when_all_files_unknown(tmp_path):
 		render_skeletons([str(tmp_path / 'bar.txt')])
 
 
+def test_render_skeletons_skips_binary_file(tmp_path):
+	python_file = tmp_path / 'foo.py'
+	binary_file = tmp_path / 'broken.py'
+	python_file.write_text('class Foo:\n    pass\n')
+	binary_file.write_bytes(b'\xff\xfe\x00\x00')
+
+	result = render_skeletons([str(python_file), str(binary_file)])
+
+	assert str(binary_file) not in result
+	assert 'class Foo:' in result[str(python_file)]
+
+
+def test_render_skeletons_raises_when_all_supported_files_are_binary(tmp_path):
+	binary_file = tmp_path / 'broken.py'
+	binary_file.write_bytes(b'\xff\xfe\x00\x00')
+
+	with pytest.raises(SkeletonError, match='no supported files found'):
+		render_skeletons([str(binary_file)])
+
+
 def test_render_skeletons_raises_on_missing_file():
 	with pytest.raises(SkeletonError):
 		render_skeletons(['/nonexistend/path/foo.py'])


### PR DESCRIPTION
## Summary

  This change prevents binary files from crashing the run when they are selected for rules generation or skeleton rendering.

  ## What changed

  - skip `golden_files` in `RulesAdapter` when UTF-8 decoding fails
  - reuse a small helper in `rules.py` so extraction and reconciliation behave the same
  - skip files with `UnicodeDecodeError` in `render_skeletons()` instead of raising `SkeletonError`
  - keep `OSError` behavior unchanged in `skeleton.py`
  - add regression tests for binary files in rules prompt building
  - add regression tests for binary files in skeleton rendering

  ## Why

  Previously, binary files could trigger:
  - `UnicodeDecodeError` in `compass/adapters/rules.py`
  - `SkeletonError` in `compass/skeleton.py`

  That aborted the whole run instead of gracefully skipping unreadable files.

  ## Testing

  - `.venv/bin/python -m pytest tests/unit/test_skeleton.py tests/unit/test_rules_adapter.py`
  - `.venv/bin/ruff check .`

closes #79 