### PR TITLE
feat(api): async job queue for POST /run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ TODO.md
 CLAUDE.md
 .mcp.json
 memory/
+.zed/
 
 .idea/
 COLLECTORS.md

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,4 @@
+{
+  "hard_tabs": true,
+  "tab_size": 4
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,0 @@
-{
-  "hard_tabs": true,
-  "tab_size": 4
-}

--- a/api/models.py
+++ b/api/models.py
@@ -17,6 +17,13 @@ class AdapterName(str, Enum):
 	summary = 'summary'
 
 
+class JobStatus(str, Enum):
+	queued = 'queued'
+	running = 'running'
+	done = 'done'
+	failed = 'failed'
+
+
 class RunRequest(BaseModel):
 	target_path: Path
 	adapters: list[AdapterName] = Field(min_length=1)
@@ -25,7 +32,18 @@ class RunRequest(BaseModel):
 	reanalyze: bool = False
 
 
-class RunResponse(BaseModel):
+class JobResponse(BaseModel):
+	job_id: str
+
+
+class JobStatusResponse(BaseModel):
+	job_id: str
+	status: JobStatus
+	error: str | None = None
+
+
+class JobOutputResponse(BaseModel):
+	job_id: str
 	output_paths: list[str]
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -4,19 +4,26 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 
 from api.models import (
 	AdapterName,
+	JobOutputResponse,
+	JobResponse,
+	JobStatus,
+	JobStatusResponse,
 	RulesOutputResponse,
 	RunRequest,
-	RunResponse,
 	SummaryOutputResponse,
 )
+from api.errors import _status_for_error
 from compass.config import CompassConfig
+from compass.errors import CompassError
 from compass.paths import compass_paths
 from compass.runner import run
 from compass.schemas.rules_schema import RulesOutput
@@ -25,8 +32,32 @@ from compass.schemas.summary_schema import SummaryOutput
 router = APIRouter()
 
 
-@router.post('/run', response_model=RunResponse)
-async def run_compass(request: RunRequest) -> RunResponse:
+@dataclass
+class Job:
+	status: JobStatus = JobStatus.queued
+	output_paths: list[str] = field(default_factory=list)
+	error: str | None = None
+	exc: Exception | None = None
+
+
+_jobs: dict[str, Job] = {}
+
+
+async def _run_job(job_id: str, config: CompassConfig) -> None:
+	job = _jobs[job_id]
+	job.status = JobStatus.running
+	try:
+		output_paths = await run(config)
+		job.output_paths = [str(p) for p in output_paths]
+		job.status = JobStatus.done
+	except Exception as exc:
+		job.error = str(exc)
+		job.exc = exc
+		job.status = JobStatus.failed
+
+
+@router.post('/run', response_model=JobResponse)
+async def run_compass(request: RunRequest, background_tasks: BackgroundTasks) -> JobResponse:
 	config = CompassConfig(
 		target_path=str(request.target_path),
 		adapters=[adapter.value for adapter in request.adapters],
@@ -34,8 +65,31 @@ async def run_compass(request: RunRequest) -> RunResponse:
 		lang=request.lang,
 		reanalyze=request.reanalyze,
 	)
-	output_paths = await run(config)
-	return RunResponse(output_paths=[str(path) for path in output_paths])
+	job_id = str(uuid.uuid4())
+	_jobs[job_id] = Job()
+	background_tasks.add_task(_run_job, job_id, config)
+	return JobResponse(job_id=job_id)
+
+
+@router.get('/jobs/{job_id}', response_model=JobStatusResponse)
+async def get_job_status(job_id: str) -> JobStatusResponse:
+	job = _jobs.get(job_id)
+	if job is None:
+		raise HTTPException(status_code=404, detail=f'Job not found: {job_id}')
+	return JobStatusResponse(job_id=job_id, status=job.status, error=job.error)
+
+
+@router.get('/jobs/{job_id}/output', response_model=JobOutputResponse)
+async def get_job_output(job_id: str) -> JobOutputResponse:
+	job = _jobs.get(job_id)
+	if job is None:
+		raise HTTPException(status_code=404, detail=f'Job not found: {job_id}')
+	if job.status == JobStatus.failed:
+		status_code = _status_for_error(job.exc) if isinstance(job.exc, CompassError) else 500
+		raise HTTPException(status_code=status_code, detail=job.error)
+	if job.status != JobStatus.done:
+		raise HTTPException(status_code=409, detail=f'Job is not done yet: {job.status}')
+	return JobOutputResponse(job_id=job_id, output_paths=job.output_paths)
 
 
 @router.get(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -8,6 +8,8 @@ import yaml
 from fastapi.testclient import TestClient
 
 from api.app import app
+from api.models import JobStatus
+from api.routes import Job, _jobs
 from compass.config import CompassConfig
 from compass.errors import PrerequisiteError, ProviderError, RepomixError
 
@@ -17,16 +19,22 @@ def client() -> TestClient:
 	return TestClient(app)
 
 
-def test_post_run_calls_runner_and_returns_output_paths(
+@pytest.fixture(autouse=True)
+def clear_jobs() -> None:
+	_jobs.clear()
+
+
+def test_post_run_returns_job_id_and_runs_pipeline(
 	client: TestClient,
 	monkeypatch: pytest.MonkeyPatch,
 	tmp_path: Path,
 ) -> None:
 	calls: list[CompassConfig] = []
+	output_path = tmp_path / '.compass' / 'output' / 'summary.json'
 
 	async def fake_run(config: CompassConfig) -> list[Path]:
 		calls.append(config)
-		return [tmp_path / '.compass' / 'output' / 'summary.json']
+		return [output_path]
 
 	monkeypatch.setattr('api.routes.run', fake_run)
 
@@ -42,9 +50,11 @@ def test_post_run_calls_runner_and_returns_output_paths(
 	)
 
 	assert response.status_code == 200
-	assert response.json() == {
-		'output_paths': [str(tmp_path / '.compass' / 'output' / 'summary.json')]
-	}
+	job_id = response.json()['job_id']
+	assert job_id
+	# BackgroundTasks runs synchronously in TestClient — job is done by the time we assert
+	assert _jobs[job_id].status == JobStatus.done
+	assert _jobs[job_id].output_paths == [str(output_path)]
 	assert calls == [
 		CompassConfig(
 			target_path=str(tmp_path),
@@ -54,6 +64,89 @@ def test_post_run_calls_runner_and_returns_output_paths(
 			reanalyze=True,
 		)
 	]
+
+
+@pytest.mark.parametrize(
+	('exc', 'expected_status'),
+	[
+		(PrerequisiteError('repomix', 'missing binary.', 'brew install repomix'), 422),
+		(ProviderError('summary', 'claude', 'timeout'), 502),
+		(RepomixError('repomix failed.'), 503),
+	],
+)
+def test_job_output_maps_compass_errors_to_http_status(
+	client: TestClient,
+	monkeypatch: pytest.MonkeyPatch,
+	tmp_path: Path,
+	exc: Exception,
+	expected_status: int,
+) -> None:
+	async def fake_run(_config: CompassConfig) -> list[Path]:
+		raise exc
+
+	monkeypatch.setattr('api.routes.run', fake_run)
+
+	response = client.post(
+		'/run',
+		json={'target_path': str(tmp_path), 'adapters': ['summary']},
+	)
+
+	assert response.status_code == 200
+	job_id = response.json()['job_id']
+	assert _jobs[job_id].status == JobStatus.failed
+
+	output_response = client.get(f'/jobs/{job_id}/output')
+	assert output_response.status_code == expected_status
+
+
+def test_get_job_status_returns_current_status(client: TestClient) -> None:
+	_jobs['test-job'] = Job(status=JobStatus.running)
+
+	response = client.get('/jobs/test-job')
+
+	assert response.status_code == 200
+	assert response.json() == {'job_id': 'test-job', 'status': 'running', 'error': None}
+
+
+def test_get_job_status_returns_404_for_unknown_job(client: TestClient) -> None:
+	response = client.get('/jobs/nonexistent')
+
+	assert response.status_code == 404
+
+
+def test_get_job_output_returns_paths_when_done(client: TestClient, tmp_path: Path) -> None:
+	path = str(tmp_path / '.compass' / 'output' / 'summary.json')
+	_jobs['test-job'] = Job(status=JobStatus.done, output_paths=[path])
+
+	response = client.get('/jobs/test-job/output')
+
+	assert response.status_code == 200
+	assert response.json() == {'job_id': 'test-job', 'output_paths': [path]}
+
+
+def test_get_job_output_returns_409_when_not_done(client: TestClient) -> None:
+	_jobs['test-job'] = Job(status=JobStatus.running)
+
+	response = client.get('/jobs/test-job/output')
+
+	assert response.status_code == 409
+
+
+def test_get_job_output_returns_500_for_unexpected_errors(client: TestClient) -> None:
+	_jobs['test-job'] = Job(
+		status=JobStatus.failed, error='something went wrong', exc=RuntimeError('oops')
+	)
+
+	response = client.get('/jobs/test-job/output')
+
+	assert response.status_code == 500
+	assert response.json()['detail'] == 'something went wrong'
+
+
+def test_get_job_output_returns_404_for_unknown_job(client: TestClient) -> None:
+	response = client.get('/jobs/nonexistent/output')
+
+	assert response.status_code == 404
 
 
 def test_get_output_summary_returns_schema_aligned_json(
@@ -141,36 +234,6 @@ def test_get_output_returns_404_when_artifact_is_missing(
 	assert response.json() == {'detail': 'Output file not found: summary.json'}
 
 
-def test_compass_errors_are_mapped_to_http_status_codes(
-	client: TestClient,
-	monkeypatch: pytest.MonkeyPatch,
-	tmp_path: Path,
-) -> None:
-	async def fake_run_prereq(config: CompassConfig) -> list[Path]:
-		raise PrerequisiteError('repomix', 'missing binary.', 'brew install repomix')
-
-	monkeypatch.setattr('api.routes.run', fake_run_prereq)
-
-	response = client.post(
-		'/run',
-		json={'target_path': str(tmp_path), 'adapters': ['rules']},
-	)
-
-	assert response.status_code == 422
-
-	async def fake_run_provider(config: CompassConfig) -> list[Path]:
-		raise ProviderError('summary', 'claude', 'timeout')
-
-	monkeypatch.setattr('api.routes.run', fake_run_provider)
-
-	response = client.post(
-		'/run',
-		json={'target_path': str(tmp_path), 'adapters': ['summary']},
-	)
-
-	assert response.status_code == 502
-
-
 def test_post_run_rejects_empty_adapters_list(
 	client: TestClient,
 	tmp_path: Path,
@@ -199,21 +262,3 @@ def test_post_run_rejects_missing_body(client: TestClient) -> None:
 	response = client.post('/run')
 
 	assert response.status_code == 422
-
-
-def test_repomix_error_is_mapped_to_503(
-	client: TestClient,
-	monkeypatch: pytest.MonkeyPatch,
-	tmp_path: Path,
-) -> None:
-	async def fake_run(_config: CompassConfig) -> list[Path]:
-		raise RepomixError('repomix failed.')
-
-	monkeypatch.setattr('api.routes.run', fake_run)
-
-	response = client.post(
-		'/run',
-		json={'target_path': str(tmp_path), 'adapters': ['summary']},
-	)
-
-	assert response.status_code == 503


### PR DESCRIPTION
## Summary

- `POST /run` now returns a `job_id` immediately and runs the pipeline via `BackgroundTasks`, eliminating long-held HTTP connections and timeout risk
- Added `GET /jobs/{id}` to poll job status (`queued → running → done | failed`)
- Added `GET /jobs/{id}/output` to retrieve output paths once done; failed jobs surface the same HTTP status codes (422/502/503) as the previous synchronous route by re-applying the existing `_status_for_error` mapping

## Test plan

- [x] `POST /run` returns 200 with `job_id` immediately
- [x] `GET /jobs/{id}` reflects live job status
- [x] `GET /jobs/{id}/output` returns 409 while running, output paths when done
- [x] `PrerequisiteError` → 422, `ProviderError` → 502, `RepomixError` → 503 via `GET /jobs/{id}/output`
- [x] All 16 unit tests pass (`pytest tests/unit/test_api.py`)

closes #82 