### PR TITLE
feat(windows): add Windows support for codebase-memory-mcp auto-download

### DIFF
--- a/compass/prerequisites.py
+++ b/compass/prerequisites.py
@@ -36,6 +36,10 @@ CODEBASE_MEMORY_MCP_RELEASES: Final[dict[tuple[str, str], str]] = {
 		'https://github.com/DeusData/codebase-memory-mcp/releases/latest/download/'
 		'codebase-memory-mcp-linux-amd64.tar.gz'
 	),
+	('Windows', 'AMD64'): (
+		'https://github.com/DeusData/codebase-memory-mcp/releases/latest/download/'
+		'codebase-memory-mcp-windows-amd64.exe'
+	),
 }
 
 
@@ -119,23 +123,38 @@ def _find_codebase_memory_mcp() -> Path | None:
 
 
 def _manual_codebase_memory_mcp_install_instructions(download_url: str | None = None) -> str:
-	install_path = '~/.compass/bin/codebase-memory-mcp'
-	if download_url is not None:
-		first_step = f'1. Download the archive from {download_url}'
+	system = platform.system()
+	if system == 'Windows':
+		install_path = r'%USERPROFILE%\.compass\bin\codebase-memory-mcp.exe'
+		if download_url is not None:
+			first_step = f'1. Download {download_url}'
+		else:
+			first_step = (
+				'1. Open https://github.com/DeusData/codebase-memory-mcp/releases/latest '
+				'and download codebase-memory-mcp-windows-amd64.exe'
+			)
+		steps = [
+			first_step,
+			f'2. Move it to {install_path}',
+			f'3. Run in PowerShell: Unblock-File -Path "{install_path}"',
+		]
 	else:
-		first_step = (
-			'1. Open https://github.com/DeusData/codebase-memory-mcp/releases/latest '
-			'and download the archive matching your platform'
-		)
-
-	steps = [
-		first_step,
-		f'2. Extract it - the file named {CODEBASE_MEMORY_MCP} inside is the binary',
-		f'3. Move it to {install_path}',
-		f'4. Run chmod +x {install_path}',
-	]
-	if platform.system() == 'Darwin':
-		steps.append(f'5. Run xattr -d com.apple.quarantine {install_path} to bypass Gatekeeper')
+		install_path = '~/.compass/bin/codebase-memory-mcp'
+		if download_url is not None:
+			first_step = f'1. Download the archive from {download_url}'
+		else:
+			first_step = (
+				'1. Open https://github.com/DeusData/codebase-memory-mcp/releases/latest '
+				'and download the archive matching your platform'
+			)
+		steps = [
+			first_step,
+			f'2. Extract it - the file named {CODEBASE_MEMORY_MCP} inside is the binary',
+			f'3. Move it to {install_path}',
+			f'4. Run chmod +x {install_path}',
+		]
+		if system == 'Darwin':
+			steps.append(f'5. Run xattr -d com.apple.quarantine {install_path} to bypass Gatekeeper')
 	return '\n'.join(steps)
 
 
@@ -146,7 +165,7 @@ def _download_codebase_memory_mcp() -> Path:
 
 	try:
 		with urlopen(download_url, timeout=30) as response:  # nosec B310
-			archive_bytes = response.read()
+			payload_bytes = response.read()
 	except OSError as error:
 		raise PrerequisiteError(
 			CODEBASE_MEMORY_MCP,
@@ -154,14 +173,17 @@ def _download_codebase_memory_mcp() -> Path:
 			_manual_codebase_memory_mcp_install_instructions(download_url),
 		) from error
 
-	try:
-		binary_bytes = _extract_codebase_memory_mcp_binary(archive_bytes)
-	except (tarfile.TarError, ValueError) as error:
-		raise PrerequisiteError(
-			CODEBASE_MEMORY_MCP,
-			'The downloaded archive could not be unpacked safely.',
-			_manual_codebase_memory_mcp_install_instructions(download_url),
-		) from error
+	if download_url.endswith('.exe'):
+		binary_bytes = payload_bytes
+	else:
+		try:
+			binary_bytes = _extract_codebase_memory_mcp_binary(payload_bytes)
+		except (tarfile.TarError, ValueError) as error:
+			raise PrerequisiteError(
+				CODEBASE_MEMORY_MCP,
+				'The downloaded archive could not be unpacked safely.',
+				_manual_codebase_memory_mcp_install_instructions(download_url),
+			) from error
 
 	target_path.write_bytes(binary_bytes)
 	target_path.chmod(_executable_mode(target_path))
@@ -196,7 +218,8 @@ def _codebase_memory_mcp_download_url() -> str:
 
 
 def _local_codebase_memory_mcp_path() -> Path:
-	return Path.home() / '.compass' / 'bin' / CODEBASE_MEMORY_MCP
+	name = CODEBASE_MEMORY_MCP + ('.exe' if platform.system() == 'Windows' else '')
+	return Path.home() / '.compass' / 'bin' / name
 
 
 def _executable_mode(path: Path) -> int:

--- a/compass/prerequisites.py
+++ b/compass/prerequisites.py
@@ -154,7 +154,9 @@ def _manual_codebase_memory_mcp_install_instructions(download_url: str | None = 
 			f'4. Run chmod +x {install_path}',
 		]
 		if system == 'Darwin':
-			steps.append(f'5. Run xattr -d com.apple.quarantine {install_path} to bypass Gatekeeper')
+			steps.append(
+				f'5. Run xattr -d com.apple.quarantine {install_path} to bypass Gatekeeper'
+			)
 	return '\n'.join(steps)
 
 

--- a/tests/unit/test_prerequisites.py
+++ b/tests/unit/test_prerequisites.py
@@ -224,6 +224,77 @@ def test_check_raises_when_codebase_memory_download_fails_without_gatekeeper_ste
 	assert 'com.apple.quarantine' not in message
 
 
+def test_check_auto_downloads_codebase_memory_mcp_on_windows(
+	tmp_path: Path,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	home_dir = tmp_path / 'home'
+
+	monkeypatch.setattr('compass.prerequisites.Path.home', lambda: home_dir)
+	monkeypatch.setattr(
+		'compass.prerequisites.importlib.util.find_spec',
+		lambda module_name: SimpleNamespace(name=module_name),
+	)
+
+	def fake_which(name: str) -> str | None:
+		if name in {'codebase-memory-mcp', 'codebase-memory-mcp.exe'}:
+			return None
+		return f'/usr/bin/{name}'
+
+	monkeypatch.setattr('compass.prerequisites.which', fake_which)
+	monkeypatch.setattr('compass.prerequisites.platform.system', lambda: 'Windows')
+	monkeypatch.setattr('compass.prerequisites.platform.machine', lambda: 'AMD64')
+
+	raw_exe_bytes = b'MZ\x00\x00fake windows binary'
+	monkeypatch.setattr(
+		'compass.prerequisites.urlopen',
+		lambda url, timeout: io.BytesIO(raw_exe_bytes),
+	)
+
+	check()
+
+	binary_path = home_dir / '.compass' / 'bin' / 'codebase-memory-mcp.exe'
+	assert binary_path.exists()
+	assert binary_path.read_bytes() == raw_exe_bytes
+
+
+def test_check_raises_when_codebase_memory_download_fails_on_windows(
+	tmp_path: Path,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	home_dir = tmp_path / 'home'
+
+	monkeypatch.setattr('compass.prerequisites.Path.home', lambda: home_dir)
+	monkeypatch.setattr(
+		'compass.prerequisites.importlib.util.find_spec',
+		lambda module_name: SimpleNamespace(name=module_name),
+	)
+
+	def fake_which(name: str) -> str | None:
+		if name in {'codebase-memory-mcp', 'codebase-memory-mcp.exe'}:
+			return None
+		return f'/usr/bin/{name}'
+
+	monkeypatch.setattr('compass.prerequisites.which', fake_which)
+	monkeypatch.setattr('compass.prerequisites.platform.system', lambda: 'Windows')
+	monkeypatch.setattr('compass.prerequisites.platform.machine', lambda: 'AMD64')
+
+	def fake_urlopen(url: str, timeout: int) -> io.BytesIO:
+		raise OSError('network down')
+
+	monkeypatch.setattr('compass.prerequisites.urlopen', fake_urlopen)
+
+	with pytest.raises(PrerequisiteError) as exc_info:
+		check()
+
+	message = str(exc_info.value)
+	assert 'Missing prerequisite: codebase-memory-mcp' in message
+	assert 'The auto-download failed while fetching the release archive.' in message
+	assert 'Unblock-File' in message
+	assert 'chmod' not in message
+	assert 'com.apple.quarantine' not in message
+
+
 def _build_codebase_memory_archive() -> bytes:
 	buffer = io.BytesIO()
 	with tarfile.open(fileobj=buffer, mode='w:gz') as archive:


### PR DESCRIPTION
## Summary

- Adds `('Windows', 'AMD64')` entry to `CODEBASE_MEMORY_MCP_RELEASES` pointing to the raw `.exe` artifact on GitHub releases
- Skips tar extraction for `.exe` downloads — the payload is written directly as the binary
- `_local_codebase_memory_mcp_path()` appends `.exe` on Windows so path detection works correctly
- `_manual_codebase_memory_mcp_install_instructions()` shows Windows-appropriate steps (PowerShell `Unblock-File`, no `chmod`, no Gatekeeper note)

## Test plan

- [x] `test_check_auto_downloads_codebase_memory_mcp_on_windows` — mocks platform as Windows/AMD64, verifies raw `.exe` bytes written to `~/.compass/bin/codebase-memory-mcp.exe` without tar extraction
- [x] `test_check_raises_when_codebase_memory_download_fails_on_windows` — verifies error message contains `Unblock-File`, no `chmod`, no `com.apple.quarantine`
- [x] All 11 prerequisite tests pass

closes #78 