### PR TITLE
[v2] API: add TTL-based cleanup for in-memory job store

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import yaml
@@ -30,6 +31,7 @@ from compass.schemas.rules_schema import RulesOutput
 from compass.schemas.summary_schema import SummaryOutput
 
 router = APIRouter()
+_JOB_TTL = timedelta(minutes=30)
 
 
 @dataclass
@@ -38,9 +40,25 @@ class Job:
 	output_paths: list[str] = field(default_factory=list)
 	error: str | None = None
 	exc: Exception | None = None
+	finished_at: datetime | None = None
 
 
 _jobs: dict[str, Job] = {}
+
+
+def _utc_now() -> datetime:
+	return datetime.now(timezone.utc)
+
+
+def _cleanup_expired_jobs() -> None:
+	now = _utc_now()
+	expired_job_ids = [
+		job_id
+		for job_id, job in _jobs.items()
+		if job.finished_at is not None and now - job.finished_at >= _JOB_TTL
+	]
+	for job_id in expired_job_ids:
+		del _jobs[job_id]
 
 
 async def _run_job(job_id: str, config: CompassConfig) -> None:
@@ -50,14 +68,17 @@ async def _run_job(job_id: str, config: CompassConfig) -> None:
 		output_paths = await run(config)
 		job.output_paths = [str(p) for p in output_paths]
 		job.status = JobStatus.done
+		job.finished_at = _utc_now()
 	except Exception as exc:
 		job.error = str(exc)
 		job.exc = exc
 		job.status = JobStatus.failed
+		job.finished_at = _utc_now()
 
 
 @router.post('/run', response_model=JobResponse)
 async def run_compass(request: RunRequest, background_tasks: BackgroundTasks) -> JobResponse:
+	_cleanup_expired_jobs()
 	config = CompassConfig(
 		target_path=str(request.target_path),
 		adapters=[adapter.value for adapter in request.adapters],

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -147,6 +148,58 @@ def test_get_job_output_returns_404_for_unknown_job(client: TestClient) -> None:
 	response = client.get('/jobs/nonexistent/output')
 
 	assert response.status_code == 404
+
+
+def test_post_run_cleans_up_expired_finished_jobs(
+	client: TestClient,
+	monkeypatch: pytest.MonkeyPatch,
+	tmp_path: Path,
+) -> None:
+	expired_time = datetime.now(timezone.utc) - timedelta(minutes=31)
+	_jobs['expired-done'] = Job(status=JobStatus.done, finished_at=expired_time)
+	_jobs['expired-failed'] = Job(
+		status=JobStatus.failed,
+		error='failed',
+		finished_at=expired_time,
+	)
+
+	async def fake_run(_config: CompassConfig) -> list[Path]:
+		return [tmp_path / '.compass' / 'output' / 'summary.json']
+
+	monkeypatch.setattr('api.routes.run', fake_run)
+
+	response = client.post(
+		'/run',
+		json={'target_path': str(tmp_path), 'adapters': ['summary']},
+	)
+
+	assert response.status_code == 200
+	assert 'expired-done' not in _jobs
+	assert 'expired-failed' not in _jobs
+
+
+def test_post_run_keeps_recent_finished_jobs_and_running_jobs(
+	client: TestClient,
+	monkeypatch: pytest.MonkeyPatch,
+	tmp_path: Path,
+) -> None:
+	recent_time = datetime.now(timezone.utc) - timedelta(minutes=29)
+	_jobs['recent-done'] = Job(status=JobStatus.done, finished_at=recent_time)
+	_jobs['running'] = Job(status=JobStatus.running)
+
+	async def fake_run(_config: CompassConfig) -> list[Path]:
+		return [tmp_path / '.compass' / 'output' / 'summary.json']
+
+	monkeypatch.setattr('api.routes.run', fake_run)
+
+	response = client.post(
+		'/run',
+		json={'target_path': str(tmp_path), 'adapters': ['summary']},
+	)
+
+	assert response.status_code == 200
+	assert 'recent-done' in _jobs
+	assert 'running' in _jobs
 
 
 def test_get_output_summary_returns_schema_aligned_json(


### PR DESCRIPTION
## Summary
  Adds a minimal TTL-based cleanup for in-memory API jobs so completed entries do not accumulate indefinitely during long-running server sessions.

## What Changed

  - Added a 30-minute job TTL in api/routes.py:34.
  - Extended the Job dataclass with finished_at to record when a job reaches done or failed (api/routes.py:37).
  - Set finished_at in _run_job() when background execution completes successfully or fails (api/routes.py:64).
  - Added _cleanup_expired_jobs() and invoke it on each POST /run, removing only terminal jobs older than the TTL before enqueuing a new
    job (api/routes.py:53, api/routes.py:79).

  ## Why This Approach
  This keeps the fix small and dependency-free:

  - no background task or lifespan wiring
  - no change to active job behavior
  - cleanup happens opportunistically on new submissions, which is sufficient for the current dev-server use case

  ## Tests
  Added unit coverage in tests/unit/test_api.py:153 for:

  - expired done/failed jobs are removed
  - recent completed jobs are retained
  - running jobs are never cleaned up

  ## Verified with:

  ./.venv/bin/pytest tests/unit/test_api.py